### PR TITLE
[Feature] add spring socket configuration 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-websocket")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -1,0 +1,10 @@
+> Author: jungchanSon  
+> Date: 2025.06.25
+
+Redis 설정에 대한 문서입니다.
+
+# RedisTemplate
+`GenericJackson2JsonRedisSerializer`을 Serializer로 설정해, JSON 형식의 데이터로 직렬화하여 관리하도록 하였습니다.
+
+# RedisMessageListenerContainer
+추후, 스케일-아웃을 고려하여, Redis Listener Container를 Bean으로 등록하였습니다.

--- a/docs/socket/socket.md
+++ b/docs/socket/socket.md
@@ -1,0 +1,31 @@
+> Author: jungchanSon  
+> Date: 2025.06.25 
+
+Web Socket 설정에 대한 문서입니다.
+
+# STOMP
+STOMP(Simple Text Oriented Messaging Protocol) 서브 프로토콜을 사용하고 있습니다.
+
+# EndPoints
+1. Connection:   
+    `/wss/connection`
+2. subscribe prefix:  
+    `/topic`
+3. publish prefix:  
+    `/app`
+
+# 연결 작업
+클라이언트의 웹 소켓 연결에 대한 관리는 redis로 관리하고 있습니다.
+
+### 웹 소켓 최초 연결시
+웹 소켓에 최초 연결 시, 아래의 데이터들이 redis에 저장됩니다.
+
+| Key                           | Value         |
+|-------------------------------|---------------|
+| sessionId:{sessionId}:roomId  | roomId        |
+| sessionId:{sessionId}:userName | userName      |
+| room:{roomId}:sessionIds      | [...sessionId] |
+| room:{roomId}:userNames      | [...userName] |
+
+### 웹 소켓 연결 해제시
+위 소켓 연결시 저정한 데이터들을 삭제합니다.

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -1,0 +1,60 @@
+package com.picpic.server.common.config.WebSocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        String roomId = headerAccessor.getFirstNativeHeader("roomId");
+        Principal user = headerAccessor.getUser();
+
+        if (roomId != null) {
+            redisTemplate.opsForValue().set("sessionId:"+sessionId, roomId);
+            redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
+
+            if(user != null) {
+                redisTemplate.opsForSet().add("room:"+roomId+":userNames", user.getName());
+                redisTemplate.opsForValue().set("sessionId:"+sessionId+":userName", user.getName());
+            }
+
+            headerAccessor.getSessionAttributes().put("roomId", roomId);
+            log.info("[STOMP] CONNECT roomId: {}, sessionId: {}", roomId, sessionId);
+        }
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        Principal user = headerAccessor.getUser();
+        String sessionId = headerAccessor.getSessionId();
+        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId).toString();
+
+        redisTemplate.delete("sessionId:"+sessionId);
+        redisTemplate.opsForSet().remove("room:"+roomId+":sessionIds", sessionId);
+
+        if(user != null) {
+            redisTemplate.opsForSet().remove("room:"+roomId+":userNames", user.getName());
+            redisTemplate.delete("sessionId:"+sessionId+":userName");
+        }
+        log.info("[STOMP] DISCONNECT roomId: {}, sessionId: {}", roomId, sessionId);
+    }
+}

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -27,7 +27,7 @@ public class WebSocketEventListener {
         Principal user = headerAccessor.getUser();
 
         if (roomId != null) {
-            redisTemplate.opsForValue().set("sessionId:"+sessionId, roomId);
+            redisTemplate.opsForValue().set("sessionId:"+sessionId+":roomId", roomId);
             redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
 
             if(user != null) {
@@ -46,9 +46,9 @@ public class WebSocketEventListener {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         Principal user = headerAccessor.getUser();
         String sessionId = headerAccessor.getSessionId();
-        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId).toString();
+        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId+":roomId").toString();
 
-        redisTemplate.delete("sessionId:"+sessionId);
+        redisTemplate.delete("sessionId:"+sessionId+":roomId");
         redisTemplate.opsForSet().remove("room:"+roomId+":sessionIds", sessionId);
 
         if(user != null) {

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
@@ -1,0 +1,28 @@
+package com.picpic.server.common.config.WebSocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/wss/connection")
+                .setAllowedOriginPatterns("*");
+
+        registry.addEndpoint("/wss/connection")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/picpic/server/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/picpic/server/common/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.picpic.server.common.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(connectionFactory);
+        template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+
+        container.setConnectionFactory(connectionFactory);
+
+        return container;
+    }
+
+}


### PR DESCRIPTION
# Related Issue
#2 

# Description
웹 소켓에 대한 Configuration을 추가하였습니다.

1. Endpoint 2개 추가
WebSocket을 지원하지 않는 브라우저들의 연결 호환성을 위해 `.withSockJs()`를 사용하였습니다. 추가로, `PostMan`에서 테스트할 수 있도록 `withSockJs()`를 제외한 endPoint를 추가하였습니다.
```
public void registerStompEndpoints(StompEndpointRegistry registry) {
        registry.addEndpoint("/wss/connection")
                .setAllowedOriginPatterns("*");

        registry.addEndpoint("/wss/connection")
                .setAllowedOriginPatterns("*")
                .withSockJS();
    }
```

2. 소켓 연결-연결해제 시 데이터들은 레디스로 추가 관리하고 있습니다.
[docs/socket/socket.md](docs/socket/socket.md)에 저장되는 데이터들을 작성했습니다.

# Related Docs
- [Redis](docs/redis/redis.md)
- [Socket](docs/socket/socket.md)