### PR TITLE
[Feature] add create room api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-websocket")
+	implementation("com.github.f4b6a3:tsid-creator:5.2.6")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-websocket")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/docs/redis/redis.md
+++ b/docs/redis/redis.md
@@ -1,0 +1,10 @@
+> Author: jungchanSon  
+> Date: 2025.06.25
+
+Redis 설정에 대한 문서입니다.
+
+# RedisTemplate
+`GenericJackson2JsonRedisSerializer`을 Serializer로 설정해, JSON 형식의 데이터로 직렬화하여 관리하도록 하였습니다.
+
+# RedisMessageListenerContainer
+추후, 스케일-아웃을 고려하여, Redis Listener Container를 Bean으로 등록하였습니다.

--- a/docs/socket/socket.md
+++ b/docs/socket/socket.md
@@ -1,0 +1,31 @@
+> Author: jungchanSon  
+> Date: 2025.06.25 
+
+Web Socket 설정에 대한 문서입니다.
+
+# STOMP
+STOMP(Simple Text Oriented Messaging Protocol) 서브 프로토콜을 사용하고 있습니다.
+
+# EndPoints
+1. Connection:   
+    `/wss/connection`
+2. subscribe prefix:  
+    `/topic`
+3. publish prefix:  
+    `/app`
+
+# 연결 작업
+클라이언트의 웹 소켓 연결에 대한 관리는 redis로 관리하고 있습니다.
+
+### 웹 소켓 최초 연결시
+웹 소켓에 최초 연결 시, 아래의 데이터들이 redis에 저장됩니다.
+
+| Key                           | Value         |
+|-------------------------------|---------------|
+| sessionId:{sessionId}:roomId  | roomId        |
+| sessionId:{sessionId}:userName | userName      |
+| room:{roomId}:sessionIds      | [...sessionId] |
+| room:{roomId}:userNames      | [...userName] |
+
+### 웹 소켓 연결 해제시
+위 소켓 연결시 저정한 데이터들을 삭제합니다.

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -1,0 +1,60 @@
+package com.picpic.server.common.config.WebSocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        String roomId = headerAccessor.getFirstNativeHeader("roomId");
+        Principal user = headerAccessor.getUser();
+
+        if (roomId != null) {
+            redisTemplate.opsForValue().set("sessionId:"+sessionId, roomId);
+            redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
+
+            if(user != null) {
+                redisTemplate.opsForSet().add("room:"+roomId+":userNames", user.getName());
+                redisTemplate.opsForValue().set("sessionId:"+sessionId+":userName", user.getName());
+            }
+
+            headerAccessor.getSessionAttributes().put("roomId", roomId);
+            log.info("[STOMP] CONNECT roomId: {}, sessionId: {}", roomId, sessionId);
+        }
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        Principal user = headerAccessor.getUser();
+        String sessionId = headerAccessor.getSessionId();
+        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId).toString();
+
+        redisTemplate.delete("sessionId:"+sessionId);
+        redisTemplate.opsForSet().remove("room:"+roomId+":sessionIds", sessionId);
+
+        if(user != null) {
+            redisTemplate.opsForSet().remove("room:"+roomId+":userNames", user.getName());
+            redisTemplate.delete("sessionId:"+sessionId+":userName");
+        }
+        log.info("[STOMP] DISCONNECT roomId: {}, sessionId: {}", roomId, sessionId);
+    }
+}

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -26,18 +26,20 @@ public class WebSocketEventListener {
         String roomId = headerAccessor.getFirstNativeHeader("roomId");
         Principal user = headerAccessor.getUser();
 
-        if (roomId != null) {
-            redisTemplate.opsForValue().set("sessionId:"+sessionId+":roomId", roomId);
-            redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
-
-            if(user != null) {
-                redisTemplate.opsForSet().add("room:"+roomId+":userNames", user.getName());
-                redisTemplate.opsForValue().set("sessionId:"+sessionId+":userName", user.getName());
-            }
-
-            headerAccessor.getSessionAttributes().put("roomId", roomId);
-            log.info("[STOMP] CONNECT roomId: {}, sessionId: {}", roomId, sessionId);
+        if(roomId == null) {
+            return;
         }
+
+        redisTemplate.opsForValue().set("sessionId:"+sessionId+":roomId", roomId);
+        redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
+
+        if(user != null) {
+            redisTemplate.opsForSet().add("room:"+roomId+":userNames", user.getName());
+            redisTemplate.opsForValue().set("sessionId:"+sessionId+":userName", user.getName());
+        }
+
+        headerAccessor.getSessionAttributes().put("roomId", roomId);
+        log.info("[STOMP] CONNECT roomId: {}, sessionId: {}", roomId, sessionId);
     }
 
     @EventListener

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -27,7 +27,7 @@ public class WebSocketEventListener {
         Principal user = headerAccessor.getUser();
 
         if (roomId != null) {
-            redisTemplate.opsForValue().set("sessionId:"+sessionId, roomId);
+            redisTemplate.opsForValue().set("sessionId:"+sessionId+":roomId", roomId);
             redisTemplate.opsForSet().add("room:"+roomId+":sessionIds", sessionId);
 
             if(user != null) {
@@ -46,9 +46,9 @@ public class WebSocketEventListener {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         Principal user = headerAccessor.getUser();
         String sessionId = headerAccessor.getSessionId();
-        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId).toString();
+        String roomId = redisTemplate.opsForValue().get("sessionId:"+sessionId+":roomId").toString();
 
-        redisTemplate.delete("sessionId:"+sessionId);
+        redisTemplate.delete("sessionId:"+sessionId+":roomId");
         redisTemplate.opsForSet().remove("room:"+roomId+":sessionIds", sessionId);
 
         if(user != null) {

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
@@ -1,0 +1,28 @@
+package com.picpic.server.common.config.WebSocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/wss/connection")
+                .setAllowedOriginPatterns("*");
+
+        registry.addEndpoint("/wss/connection")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
@@ -1,14 +1,20 @@
 package com.picpic.server.common.config.WebSocket;
 
+import com.picpic.server.common.config.WebSocket.interceptor.RoomValidationInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final RoomValidationInterceptor roomValidationInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -24,5 +30,11 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+
+        registration.interceptors(roomValidationInterceptor);
     }
 }

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -1,0 +1,53 @@
+package com.picpic.server.common.config.WebSocket.interceptor;
+
+import com.picpic.server.room.entity.RoomEntity;
+import com.picpic.server.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomValidationInterceptor implements ChannelInterceptor {
+
+    private final RoomRepository roomRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        StompCommand command = accessor.getCommand();
+
+        if (StompCommand.CONNECT.equals(command)) {
+            String roomId = accessor.getFirstNativeHeader("roomId");
+
+            if (roomId != null) {
+                try {
+                    validateRoomExist(roomId);
+                } catch (Exception e) {
+                    log.warn("[STOMP] CONNECT rejected - Room not found: {}", roomId);
+                    throw new IllegalArgumentException("존재하지 않는 방입니다: " + roomId);
+                }
+            }
+        }
+
+        return message;
+    }
+
+    private void validateRoomExist(String roomId) {
+
+        Optional<RoomEntity> roomEntity = roomRepository.findById(roomId);
+
+        if(roomEntity.isEmpty()) {
+            throw new RuntimeException("Room is no exsit: "+roomId);
+        }
+    }
+}

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -1,5 +1,6 @@
 package com.picpic.server.common.config.WebSocket.interceptor;
 
+import com.picpic.server.common.security.MemberPrincipalDetail;
 import com.picpic.server.room.entity.RoomEntity;
 import com.picpic.server.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,13 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
         StompCommand command = accessor.getCommand();
 
         if (StompCommand.CONNECT.equals(command)) {
+            String token = accessor.getFirstNativeHeader("Authorization");
+
+            if (token != null) {
+                // TODO: Jwt 유틸 개발 이후, 이 부분에 토큰 안에 담긴 내용으로 principal 생성해야함
+                MemberPrincipalDetail principal = new MemberPrincipalDetail(Long.parseLong(token));
+                accessor.setUser(principal);
+            }
             String roomId = accessor.getFirstNativeHeader("roomId");
 
             if (roomId != null) {
@@ -34,7 +42,6 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
                     validateRoomExist(roomId);
                 } catch (Exception e) {
                     log.warn("[STOMP] CONNECT rejected - Room not found: {}", roomId);
-                    throw new IllegalArgumentException("존재하지 않는 방입니다: " + roomId);
                 }
             }
         }

--- a/src/main/java/com/picpic/server/common/config/jpa/JpaConfig.java
+++ b/src/main/java/com/picpic/server/common/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.picpic.server.common.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/picpic/server/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/picpic/server/common/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.picpic.server.common.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(connectionFactory);
+        template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+
+        container.setConnectionFactory(connectionFactory);
+
+        return container;
+    }
+
+}

--- a/src/main/java/com/picpic/server/common/security/MemberPrincipalDetail.java
+++ b/src/main/java/com/picpic/server/common/security/MemberPrincipalDetail.java
@@ -1,0 +1,9 @@
+package com.picpic.server.common.security;
+
+import lombok.Builder;
+
+@Builder
+public record MemberPrincipalDetail (
+        Long memberId
+) {
+}

--- a/src/main/java/com/picpic/server/common/security/MemberPrincipalDetail.java
+++ b/src/main/java/com/picpic/server/common/security/MemberPrincipalDetail.java
@@ -2,8 +2,13 @@ package com.picpic.server.common.security;
 
 import lombok.Builder;
 
+import java.security.Principal;
+
 @Builder
-public record MemberPrincipalDetail (
-        Long memberId
-) {
+public record MemberPrincipalDetail (Long memberId) implements Principal{
+
+    @Override
+    public String getName() {
+        return memberId.toString();
+    }
 }

--- a/src/main/java/com/picpic/server/common/util/IdUtils.java
+++ b/src/main/java/com/picpic/server/common/util/IdUtils.java
@@ -1,0 +1,10 @@
+package com.picpic.server.common.util;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+
+public class IdUtils {
+
+    public static long generateId() {
+        return TsidCreator.getTsid().toLong();
+    }
+}

--- a/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
+++ b/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
@@ -1,0 +1,24 @@
+package com.picpic.server.room.controller;
+
+import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.room.service.usecase.CreateRoomUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CreatePhotoRoomController {
+
+    private final CreateRoomUseCase createRoomUseCase;
+
+    @PostMapping("/room")
+    public String createRoom(@AuthenticationPrincipal MemberPrincipalDetail memberDetail) {
+        return createRoomUseCase.createRoom(memberDetail.memberId());
+    }
+}

--- a/src/main/java/com/picpic/server/room/entity/RoomEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomEntity.java
@@ -1,0 +1,16 @@
+package com.picpic.server.room.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.redis.core.RedisHash;
+
+@Builder
+@RedisHash(value = "room", timeToLive = 3600)
+@AllArgsConstructor
+public class RoomEntity {
+
+    @Id
+    private String id;
+    private String memberId;
+}

--- a/src/main/java/com/picpic/server/room/entity/RoomEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomEntity.java
@@ -11,6 +11,6 @@ import org.springframework.data.redis.core.RedisHash;
 public class RoomEntity {
 
     @Id
-    private String id;
+    private Long roomId;
     private String memberId;
 }

--- a/src/main/java/com/picpic/server/room/entity/RoomHistoryEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomHistoryEntity.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -22,7 +24,7 @@ public class RoomHistoryEntity {
     private Long memberId;
 
     @CreatedDate
-    private Long createdAt;
+    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
     private RoomHistoryStatus roomHistoryStatus;

--- a/src/main/java/com/picpic/server/room/entity/RoomHistoryEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomHistoryEntity.java
@@ -1,0 +1,33 @@
+package com.picpic.server.room.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomHistoryEntity {
+
+    @Id
+    private Long roomHistoryId;
+
+    private Long memberId;
+
+    @CreatedDate
+    private Long createdAt;
+
+    @Enumerated(EnumType.STRING)
+    private RoomHistoryStatus roomHistoryStatus;
+
+    public enum RoomHistoryStatus {
+        CREATE, COMPLEMENT
+    }
+}

--- a/src/main/java/com/picpic/server/room/repository/RoomHistoryRepository.java
+++ b/src/main/java/com/picpic/server/room/repository/RoomHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.picpic.server.room.repository;
+
+import com.picpic.server.room.entity.RoomHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomHistoryRepository extends JpaRepository<RoomHistoryEntity,Long> {
+}

--- a/src/main/java/com/picpic/server/room/repository/RoomRepository.java
+++ b/src/main/java/com/picpic/server/room/repository/RoomRepository.java
@@ -1,0 +1,10 @@
+package com.picpic.server.room.repository;
+
+import com.picpic.server.room.entity.RoomEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends CrudRepository<RoomEntity, String> {
+
+}

--- a/src/main/java/com/picpic/server/room/service/CreateRoomService.java
+++ b/src/main/java/com/picpic/server/room/service/CreateRoomService.java
@@ -1,0 +1,41 @@
+package com.picpic.server.room.service;
+
+import com.picpic.server.common.util.IdUtils;
+import com.picpic.server.room.entity.RoomEntity;
+import com.picpic.server.room.entity.RoomHistoryEntity;
+import com.picpic.server.room.repository.RoomHistoryRepository;
+import com.picpic.server.room.repository.RoomRepository;
+import com.picpic.server.room.service.usecase.CreateRoomUseCase;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateRoomService implements CreateRoomUseCase {
+
+    private final RoomHistoryRepository roomHistoryRepository;
+    private final RoomRepository roomRepository;
+
+    @Override
+    public String createRoom(long memberId) {
+
+        String roomId = UUID.randomUUID().toString();
+
+        roomRepository.save(RoomEntity.builder()
+                        .id(roomId)
+                        .memberId(String.valueOf(memberId))
+                        .build());
+
+        roomHistoryRepository.save(
+                RoomHistoryEntity.builder()
+                        .roomHistoryId(IdUtils.generateId())
+                        .memberId(memberId)
+                        .build());
+
+        return roomId;
+    }
+}

--- a/src/main/java/com/picpic/server/room/service/usecase/CreateRoomUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/CreateRoomUseCase.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.service.usecase;
+
+public interface CreateRoomUseCase {
+    String createRoom(long memberId);
+}


### PR DESCRIPTION
# Related Issue
#4 

## Summery
1. 의존성 추가 : Tsid 생성자 의존성 추가
2. Jpa configuration 추가
3. Stomp InboundChannel Interceptor 추가 (방 존재 유무 체크)
4. 방생성 api 추가

# Description
## 1. Tsid Creator 추가
Entity의 Id를 Tsid로 설정하기 위해, Tsid 생성 관련 의존성을 추가하였습니다. utils 패키지에 관련 클래스를 추가하였으며, 아래와 같이 사용할 수 있습니다.

```java
  IdUtils.generateId()
```
## 2. Jpa Configuration 추가
`common/config/jpa/` 패키지에 `Jpa Configuration`을 추가하였으며, `@CreatedDate`와 같은 Auditing 기능을 사용하기 위해, `@EnableJpaAuditing`를 추가하였습니다.

## 3. InboundChannel Interceptor 추가
현재, Socket 연결 시, 열견할 방이 존재하는 지 검사하는 Intercetpor를 추가하였습니다. 존재 유무는 방 생성 서비스 과정에서 저장된 Redis 데이터를 기준으로 합니다.

## 4. Create Room API 
방 생성 API를 추가하였습니다.  아래와 같이 Filter단 에서 저장된 Principal을 받아서 방을 생성 후 해당 방의 id를 반환합니다.  
```java
 @PostMapping("/room")
    public String createRoom(@AuthenticationPrincipal MemberPrincipalDetail memberDetail) {
        return createRoomUseCase.createRoom(memberDetail.memberId());
}
```
**소켓 연결 시, 클라이언트에서 header에 `{"roomId": "위에서 받은 roomId"}`를 함께 전달해야 합니다.**  
**_해당 Header 값이 없을 경우, Inbound Interceptor에서 막힘_**

방 생성 Service는 DB와 Redis에 저장되며, Redis의 경우 TTL을 1시간(3600초)로 설정하였습니다.
