### PR TITLE
Feat/#27/room capacity

### DIFF
--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -76,7 +76,7 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
 
         Integer roomCapacity = redisRoomQueryUseCase.getRoomCapacity(roomId);
         Integer currentMemberNum = redisRoomQueryUseCase.searchMember(roomId).size();
-        System.out.println("currentMemberNum = " + currentMemberNum);
+
         if(currentMemberNum >= roomCapacity ) {
             throw new RuntimeException("The room capacity is greater than the room capacity.");
         }

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -32,19 +32,28 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
             String token = accessor.getFirstNativeHeader("X-Test-Member-Id");
             String roomId = accessor.getFirstNativeHeader("roomId");
 
-            validateAlreadyEnter(token);
+            if (token == null || roomId == null) {
+                log.warn("[STOMP] CONNECT rejected - Missing token or roomId");
+                return null;
+            }
 
-            if (token != null && roomId != null) {
-                try {
-                    validateRoomExist(roomId);
-                    MemberPrincipalDetail principal = new MemberPrincipalDetail(
-                            Long.parseLong(token),
-                            "test nickname" //TODO
-                    );
-                    accessor.setUser(principal);
-                } catch (Exception e) {
-                    log.warn("[STOMP] CONNECT rejected - Room not found: {}", roomId);
-                }
+            try {
+                validateAlreadyEnter(token);
+                validateRoomCapacity(roomId);
+                validateRoomExist(roomId);
+
+                MemberPrincipalDetail principal = new MemberPrincipalDetail(
+                        Long.parseLong(token),
+                        "test nickname" //TODO
+                );
+
+                accessor.setUser(principal);
+
+                log.info("[STOMP] CONNECT approved - userId: {}, roomId: {}", token, roomId);
+            } catch (Exception e) {
+                log.warn("[STOMP] CONNECT rejected - {}", e.getMessage());
+
+                return null;
             }
         }
 
@@ -60,6 +69,16 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
     private void validateAlreadyEnter(String userId) {
         if(redisTemplate.opsForValue().get(userId+":roomId") != null) {
             throw new RuntimeException("You are already connected to a room.");
+        }
+    }
+
+    private void validateRoomCapacity(String roomId) {
+
+        Integer roomCapacity = redisRoomQueryUseCase.getRoomCapacity(roomId);
+        Integer currentMemberNum = redisRoomQueryUseCase.searchMember(roomId).size();
+        System.out.println("currentMemberNum = " + currentMemberNum);
+        if(currentMemberNum >= roomCapacity ) {
+            throw new RuntimeException("The room capacity is greater than the room capacity.");
         }
     }
 }

--- a/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
+++ b/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
@@ -2,8 +2,10 @@ package com.picpic.server.room.controller;
 
 import com.picpic.server.common.response.ApiResponse;
 import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.room.dto.CreatePhotoRoomRequestDto;
 import com.picpic.server.room.dto.CreatePhotoRoomResponseDto;
 import com.picpic.server.room.service.usecase.CreateRoomUseCase;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,12 +23,16 @@ public class CreatePhotoRoomController {
 
     @PostMapping("/room")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<CreatePhotoRoomResponseDto> createRoom(@AuthenticationPrincipal MemberPrincipalDetail memberDetail) {
+    public ApiResponse<CreatePhotoRoomResponseDto> createRoom(
+            @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+            @Valid @RequestBody CreatePhotoRoomRequestDto request
+    ) {
 
-        String createdRoomId = createRoomUseCase.createRoom(memberDetail);
+        String createdRoomId = createRoomUseCase.createRoom(memberDetail, request.roomCapacity());
 
         CreatePhotoRoomResponseDto response = CreatePhotoRoomResponseDto.builder()
                 .roomId(createdRoomId)
+                .roomCapacity(request.roomCapacity())
                 .build();
 
         return ApiResponse.success(response);

--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
@@ -1,0 +1,31 @@
+package com.picpic.server.room.controller.ws;
+
+import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.room.dto.ws.RoomCapacityRequestDto;
+import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
+import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UpdateRoomCapacityWsController {
+
+    private final UpdateRoomCapacityUseCase updateRoomCapacityUseCase;
+
+    @MessageMapping("/room/{roomId}/capacity")
+    @SendTo("/topic/room/{roomId}/capacity")
+    public RoomCapacityResponseDto updateRoomCapacity(
+            @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+            @DestinationVariable String roomId,
+            RoomCapacityRequestDto request
+    ) {
+        return updateRoomCapacityUseCase.update(memberDetail.memberId(), roomId, request.roomCapacity());
+    }
+}

--- a/src/main/java/com/picpic/server/room/dto/CreatePhotoRoomRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/CreatePhotoRoomRequestDto.java
@@ -1,0 +1,9 @@
+package com.picpic.server.room.dto;
+
+import org.hibernate.validator.constraints.Range;
+
+public record CreatePhotoRoomRequestDto (
+
+        @Range(min = 1, max = 6)
+        Integer roomCapacity
+) { }

--- a/src/main/java/com/picpic/server/room/dto/ws/RoomCapacityRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/RoomCapacityRequestDto.java
@@ -1,0 +1,6 @@
+package com.picpic.server.room.dto.ws;
+
+public record RoomCapacityRequestDto(
+        Integer roomCapacity
+) {
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/RoomCapacityResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/RoomCapacityResponseDto.java
@@ -1,0 +1,9 @@
+package com.picpic.server.room.dto.ws;
+
+import lombok.Builder;
+
+@Builder
+public record RoomCapacityResponseDto(
+        String roomId,
+        Integer roomCapacity
+) { }

--- a/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
@@ -26,6 +26,9 @@ public class RoomRedisEntity {
     @Builder.Default
     private List<RoomMember> members = new ArrayList<>();
 
+    @Builder.Default
+    private int roomCapacity = 6;
+
     public RoomRedisEntity addMember(RoomMember newMember) {
 
         List<RoomMember> updatedMembers = new ArrayList<>();

--- a/src/main/java/com/picpic/server/room/service/CreateRoomService.java
+++ b/src/main/java/com/picpic/server/room/service/CreateRoomService.java
@@ -18,11 +18,11 @@ public class CreateRoomService implements CreateRoomUseCase {
     private final RoomHistoryCommandUseCase roomHistoryCommandUseCase;
 
     @Override
-    public String createRoom(MemberPrincipalDetail creatorPrinciple) {
+    public String createRoom(MemberPrincipalDetail creatorPrinciple, Integer roomCapacity) {
         String roomId = IdUtils.generateRoomId();
 
         roomHistoryCommandUseCase.create(IdUtils.generateTsid(), creatorPrinciple.memberId());
-        redisRoomCommandUseCase.create(roomId, creatorPrinciple);
+        redisRoomCommandUseCase.create(roomId, creatorPrinciple, roomCapacity);
 
         return roomId;
     }

--- a/src/main/java/com/picpic/server/room/service/UpdateRoomCapacityService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateRoomCapacityService.java
@@ -1,0 +1,49 @@
+package com.picpic.server.room.service;
+
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
+import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateRoomCapacityService implements UpdateRoomCapacityUseCase {
+
+    private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+    private final RedisRoomCommandUseCase redisRoomCommandUseCase;
+
+    @Override
+    public RoomCapacityResponseDto update(Long memberId, String roomId, Integer roomCapacity) {
+
+        RoomMember creator = redisRoomQueryUseCase.getCreator(roomId);
+
+        validateCreatorId(memberId, creator);
+        validateOverRoomCapacityWhenUpdateRoomCapacity(roomId, roomCapacity);
+
+        redisRoomCommandUseCase.updateRoomCapacity(roomId, roomCapacity);
+
+        return RoomCapacityResponseDto.builder()
+                .roomId(roomId)
+                .roomCapacity(roomCapacity)
+                .build();
+    }
+
+    private void validateCreatorId (Long requestMemberId, RoomMember actualCreator) {
+        if(!actualCreator.getMemberId().equals(requestMemberId)) {
+            throw new RuntimeException("Access denied. Room creator privileges required.");
+        }
+    }
+
+    private void validateOverRoomCapacityWhenUpdateRoomCapacity(String roomId, Integer roomCapacity) {
+        int currentRoomMemberSize = redisRoomQueryUseCase.searchMember(roomId).size();
+
+        if(currentRoomMemberSize > roomCapacity ) {
+            throw new RuntimeException("Current room member capacity is greater than requested room capacity.");
+        }
+    }
+}

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -15,9 +15,10 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
     private final RoomRedisRepository roomRedisRepository;
 
     @Override
-    public void create(String roomId, MemberPrincipalDetail memberPrincipal) {
+    public void create(String roomId, MemberPrincipalDetail memberPrincipal, Integer roomCapacity) {
 
         RoomRedisEntity room = RoomRedisEntity.builder()
+                .roomCapacity(roomCapacity)
                 .roomId(roomId)
                 .creator(RoomMember.from(memberPrincipal))
                 .build();

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -51,4 +51,16 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 
         roomRedisRepository.save(updatedEntity);
     }
+
+    @Override
+    public void updateRoomCapacity(String roomId, Integer roomCapacity) {
+        RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+
+        RoomRedisEntity updatedRoom = roomEntity.toBuilder()
+                .roomCapacity(roomCapacity)
+                .build();
+
+        roomRedisRepository.save(updatedRoom);
+    }
 }

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
@@ -36,4 +36,14 @@ public class RedisRoomQuery implements RedisRoomQueryUseCase {
 
         return roomRedisEntity.getRoomCapacity();
     }
+
+    @Override
+    public RoomMember getCreator(String roomId) {
+
+        RoomRedisEntity roomRedisEntity = roomRedisRepository
+                .findById(roomId)
+                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+
+        return roomRedisEntity.getCreator();
+    }
 }

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
@@ -1,6 +1,7 @@
 package com.picpic.server.room.service.redis;
 
 import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.entity.RoomRedisEntity;
 import com.picpic.server.room.repository.RoomRedisRepository;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +25,15 @@ public class RedisRoomQuery implements RedisRoomQueryUseCase {
     @Override
     public boolean exist(String roomId) {
         return roomRedisRepository.existsById(roomId);
+    }
+
+    @Override
+    public Integer getRoomCapacity(String roomId) {
+
+        RoomRedisEntity roomRedisEntity = roomRedisRepository
+                .findById(roomId)
+                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+
+        return roomRedisEntity.getRoomCapacity();
     }
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/CreateRoomUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/CreateRoomUseCase.java
@@ -3,5 +3,5 @@ package com.picpic.server.room.service.usecase;
 import com.picpic.server.common.security.MemberPrincipalDetail;
 
 public interface CreateRoomUseCase {
-    String createRoom(MemberPrincipalDetail creatorPrinciple);
+    String createRoom(MemberPrincipalDetail creatorPrinciple, Integer roomCapacity);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
@@ -3,7 +3,7 @@ package com.picpic.server.room.service.usecase;
 import com.picpic.server.common.security.MemberPrincipalDetail;
 
 public interface RedisRoomCommandUseCase {
-    void create(String roomId, MemberPrincipalDetail memberPrincipal);
+    void create(String roomId, MemberPrincipalDetail memberPrincipal, Integer roomCapacity);
     void delete(String roomId);
     void addMember(String roomId, MemberPrincipalDetail memberPrincipalDetail);
     void subtractMember(String roomId, Long memberId);

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
@@ -7,4 +7,5 @@ public interface RedisRoomCommandUseCase {
     void delete(String roomId);
     void addMember(String roomId, MemberPrincipalDetail memberPrincipalDetail);
     void subtractMember(String roomId, Long memberId);
+    void updateRoomCapacity(String roomId, Integer roomCapacity);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomQueryUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomQueryUseCase.java
@@ -8,4 +8,5 @@ public interface RedisRoomQueryUseCase {
     List<RoomMember> searchMember(String roomId);
     boolean exist(String roomId);
     Integer getRoomCapacity(String roomId);
+    RoomMember getCreator(String roomId);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomQueryUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomQueryUseCase.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface RedisRoomQueryUseCase {
     List<RoomMember> searchMember(String roomId);
     boolean exist(String roomId);
+    Integer getRoomCapacity(String roomId);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/UpdateRoomCapacityUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/UpdateRoomCapacityUseCase.java
@@ -1,0 +1,7 @@
+package com.picpic.server.room.service.usecase;
+
+import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
+
+public interface UpdateRoomCapacityUseCase {
+    RoomCapacityResponseDto update(Long memberId, String roomId, Integer roomCapacity);
+}


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 방 생성 api에 인원 수 초기호 파라미터 추가
  - 소켓 연결 시, 설정한 방 인원이 초과되면 Reject Connection 
- 소켓 통신 중 방 인원 수 업데이트 기능 추가
  - 제약 사항
    1. 방을 생성한 멤버만 수정 가능 (id로 검증)
    2. 요청한 인원 수가 현재 방의 인원 수보다 작을 경우, 에러 처리
