### PR TITLE
fix/#41: deliver JWT via response body instead of cookie

### DIFF
--- a/src/main/java/com/picpic/server/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/picpic/server/common/auth/JwtTokenProvider.java
@@ -1,7 +1,6 @@
 package com.picpic.server.common.auth;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 
@@ -20,7 +19,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -101,13 +99,12 @@ public class JwtTokenProvider {
 	}
 
 	public String resolveToken(HttpServletRequest request) {
-		if (request.getCookies() == null)
-			return null;
+		String authorizationHeader = request.getHeader("Authorization");
 
-		return Arrays.stream(request.getCookies())
-			.filter(cookie -> "access-token".equals(cookie.getName()))
-			.findFirst()
-			.map(Cookie::getValue)
-			.orElse(null);
+		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+			return null;
+		}
+
+		return authorizationHeader.substring(7);
 	}
 }

--- a/src/main/java/com/picpic/server/common/auth/controller/AuthController.java
+++ b/src/main/java/com/picpic/server/common/auth/controller/AuthController.java
@@ -1,12 +1,10 @@
 package com.picpic.server.common.auth.controller;
 
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.picpic.server.common.auth.dto.GuestLoginResponseDTO;
-import com.picpic.server.common.auth.dto.GuestLoginResultDTO;
 import com.picpic.server.common.auth.service.AuthService;
 import com.picpic.server.common.response.ApiResponse;
 
@@ -21,18 +19,7 @@ public class AuthController {
 
 	@PostMapping("/api/v1/guest")
 	public ResponseEntity<ApiResponse<GuestLoginResponseDTO>> guestLogin(HttpServletResponse response) {
-		GuestLoginResultDTO res = authService.guestLogin();
-
-		ResponseCookie cookie = ResponseCookie.from("access-token", res.accessToken())
-			.httpOnly(true)
-			.secure(false)
-			.path("/")
-			.sameSite("None")
-			.maxAge(60 * 60 * 24)
-			.build();
-
-		response.addHeader("Set-Cookie", cookie.toString());
-
-		return ResponseEntity.ok(ApiResponse.success(GuestLoginResponseDTO.builder().memberId(res.memberId()).build()));
+		return ResponseEntity.ok(ApiResponse.success(authService.guestLogin()));
 	}
+
 }

--- a/src/main/java/com/picpic/server/common/auth/dto/GuestLoginResponseDTO.java
+++ b/src/main/java/com/picpic/server/common/auth/dto/GuestLoginResponseDTO.java
@@ -3,5 +3,8 @@ package com.picpic.server.common.auth.dto;
 import lombok.Builder;
 
 @Builder
-public record GuestLoginResponseDTO(Long memberId) {
+public record GuestLoginResponseDTO(
+	Long memberId,
+	String accessToken
+) {
 }

--- a/src/main/java/com/picpic/server/common/auth/service/AuthService.java
+++ b/src/main/java/com/picpic/server/common/auth/service/AuthService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.picpic.server.common.auth.JwtTokenProvider;
-import com.picpic.server.common.auth.dto.GuestLoginResultDTO;
+import com.picpic.server.common.auth.dto.GuestLoginResponseDTO;
 import com.picpic.server.member.entity.Member;
 import com.picpic.server.member.entity.Nickname;
 import com.picpic.server.member.entity.Profile;
@@ -26,7 +26,7 @@ public class AuthService {
 	private final ProfileRepository profileRepository;
 	private final NicknameRepository nicknameRepository;
 
-	public GuestLoginResultDTO guestLogin() {
+	public GuestLoginResponseDTO guestLogin() {
 		Profile profile = profileRepository.findRandom();
 		Nickname nickname = nicknameRepository.findRandom();
 
@@ -41,7 +41,10 @@ public class AuthService {
 
 		String token = jwtTokenProvider.generateToken(guest.getMemberId());
 
-		return new GuestLoginResultDTO(guest.getMemberId(), token);
+		return GuestLoginResponseDTO.builder()
+			.memberId(guest.getMemberId())
+			.accessToken(token)
+			.build();
 	}
-
 }
+


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- JWT파싱을 쿠키 방식에서 Header 방식으로 변경하였습니다.


## 📝 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요 -->
- 토큰을 따로 저장해뒀다가 Authorization 헤더에 넣어서 같이 보내주세요.
