### PR TITLE
Feat#32/add member ready

### DIFF
--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.common.security.MemberPrincipalDetail;
 import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
 
@@ -39,11 +41,12 @@ public class WebSocketEventListener {
 			= user instanceof MemberPrincipalDetail ? (MemberPrincipalDetail)user : null;
 
 		if (roomId == null) {
-			throw new RuntimeException("Room not found. : " + roomId);
+			throw new WsException(WsErrorCode.NOT_FOUND_ROOM);
+
 		}
 
 		if (memberPrincipal == null) {
-			throw new RuntimeException("Member information is missing.");
+			throw new WsException(WsErrorCode.MISSING_MEMBER_INFO);
 		}
 
 		redisRoomCommand.addMember(roomId, memberPrincipal);
@@ -63,6 +66,11 @@ public class WebSocketEventListener {
 		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
 		String sessionId = headerAccessor.getSessionId();
 		Principal user = headerAccessor.getUser();
+
+		if(user == null) {
+			return;
+		}
+
 		String roomId = redisTemplate.opsForValue().get(user.getName() + ":roomId").toString();
 
 		MemberPrincipalDetail memberPrincipal

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketEventListener.java
@@ -13,6 +13,8 @@ import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -39,11 +41,12 @@ public class WebSocketEventListener {
 			= user instanceof MemberPrincipalDetail ? (MemberPrincipalDetail)user : null;
 
 		if (roomId == null) {
-			throw new RuntimeException("Room not found. : " + roomId);
+			throw new WsException(WsErrorCode.NOT_FOUND_ROOM);
+
 		}
 
 		if (memberPrincipal == null) {
-			throw new RuntimeException("Member information is missing.");
+			throw new WsException(WsErrorCode.MISSING_MEMBER_INFO);
 		}
 
 		redisRoomCommand.addMember(roomId, memberPrincipal);
@@ -63,6 +66,11 @@ public class WebSocketEventListener {
 		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
 		String sessionId = headerAccessor.getSessionId();
 		Principal user = headerAccessor.getUser();
+
+		if(user == null) {
+			return;
+		}
+
 		String roomId = redisTemplate.opsForValue().get(user.getName() + ":roomId").toString();
 
 		MemberPrincipalDetail memberPrincipal

--- a/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/WebSocketMessageBrokerConfig.java
@@ -1,7 +1,5 @@
 package com.picpic.server.common.config.WebSocket;
 
-import com.picpic.server.common.config.WebSocket.interceptor.RoomValidationInterceptor;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -9,32 +7,45 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import com.picpic.server.common.config.WebSocket.interceptor.RoomValidationInterceptor;
+import com.picpic.server.common.config.WebSocket.interceptor.StompExceptionHandler;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final RoomValidationInterceptor roomValidationInterceptor;
+	private final RoomValidationInterceptor roomValidationInterceptor;
 
-    @Override
-    public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/wss/connection")
-                .setAllowedOriginPatterns("*");
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry
+			.setErrorHandler(new StompExceptionHandler())
+			.addEndpoint("/wss/connection")
+			.setAllowedOriginPatterns("*");
 
-        registry.addEndpoint("/wss/connection")
-                .setAllowedOriginPatterns("*")
-                .withSockJS();
-    }
+		registry
+			.setErrorHandler(new StompExceptionHandler())
+			.addEndpoint("/wss/connection")
+			.setAllowedOriginPatterns("*")
+			.withSockJS();
 
-    @Override
-    public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic");
-        registry.setApplicationDestinationPrefixes("/app");
-    }
+	}
 
-    @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/topic", "/queue"); // /queue 추가
+		registry.setApplicationDestinationPrefixes("/app");
+	}
 
-        registration.interceptors(roomValidationInterceptor);
-    }
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+
+		registration.interceptors(
+			roomValidationInterceptor
+		);
+
+	}
 }

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -1,20 +1,24 @@
 package com.picpic.server.common.config.WebSocket.interceptor;
 
+import static com.picpic.server.common.exception.WsErrorCode.*;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
-import com.picpic.server.common.auth.MemberPrincipalDetail;
-import com.picpic.server.member.entity.Member;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
 
 @Slf4j
 @Component
@@ -29,21 +33,21 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
 		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 		StompCommand command = accessor.getCommand();
 
-		if (StompCommand.CONNECT.equals(command)) {
-			// TODO: Jwt 유틸 개발 이후, 이 부분에 토큰 안에 담긴 내용으로 principal 생성해야함
-			//            String token = accessor.getFirstNativeHeader("Authorization");
-			String token = accessor.getFirstNativeHeader("X-Test-Member-Id");
-			String roomId = accessor.getFirstNativeHeader("roomId");
+        if (StompCommand.CONNECT.equals(command)) {
+            // TODO: Jwt 유틸 개발 이후, 이 부분에 토큰 안에 담긴 내용으로 principal 생성해야함
+//            String token = accessor.getFirstNativeHeader("Authorization");
+            String token = accessor.getFirstNativeHeader("X-Test-Member-Id");
+            String roomId = accessor.getFirstNativeHeader("roomId");
 
 			if (token == null || roomId == null) {
 				log.warn("[STOMP] CONNECT rejected - Missing token or roomId");
 				return null;
 			}
 
-			try {
-				validateAlreadyEnter(token);
-				validateRoomCapacity(roomId);
-				validateRoomExist(roomId);
+            try {
+                validateAlreadyEnter(token);
+                validateRoomExist(roomId);
+                validateRoomCapacity(roomId);
 
 				MemberPrincipalDetail principal = new MemberPrincipalDetail(
 					Long.parseLong(token),
@@ -51,38 +55,36 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
 					Member.Role.GUEST
 				);
 
-				accessor.setUser(principal);
+                accessor.setUser(principal);
 
-				log.info("[STOMP] CONNECT approved - userId: {}, roomId: {}", token, roomId);
-			} catch (Exception e) {
-				log.warn("[STOMP] CONNECT rejected - {}", e.getMessage());
+                log.info("[STOMP] CONNECT approved - userId: {}, roomId: {}", token, roomId);
+            } catch (WsException e) {
+                throw new MessagingException(e.getMessage(), e);
+            }
+        }
 
-				return null;
-			}
-		}
+        return message;
+    }
 
-		return message;
-	}
+    private void validateRoomExist(String roomId) {
+        if(!redisRoomQueryUseCase.exist(roomId)) {
+            throw new WsException(NOT_FOUND_ROOM);
+        }
+    }
 
-	private void validateRoomExist(String roomId) {
-		if (!redisRoomQueryUseCase.exist(roomId)) {
-			throw new RuntimeException("Room not found. : " + roomId);
-		}
-	}
+    private void validateAlreadyEnter(String userId) {
+        if(redisTemplate.opsForValue().get(userId+":roomId") != null) {
+            throw new WsException(ALREADY_CONNECTED);
+        }
+    }
 
-	private void validateAlreadyEnter(String userId) {
-		if (redisTemplate.opsForValue().get(userId + ":roomId") != null) {
-			throw new RuntimeException("You are already connected to a room.");
-		}
-	}
+    private void validateRoomCapacity(String roomId) {
 
-	private void validateRoomCapacity(String roomId) {
+        Integer roomCapacity = redisRoomQueryUseCase.getRoomCapacity(roomId);
+        Integer currentMemberNum = redisRoomQueryUseCase.searchMember(roomId).size();
 
-		Integer roomCapacity = redisRoomQueryUseCase.getRoomCapacity(roomId);
-		Integer currentMemberNum = redisRoomQueryUseCase.searchMember(roomId).size();
-
-		if (currentMemberNum >= roomCapacity) {
-			throw new RuntimeException("The room capacity is greater than the room capacity.");
-		}
-	}
+        if(currentMemberNum >= roomCapacity ) {
+            throw new WsException(EXCEED_ROOM_CAPACITY);
+        }
+    }
 }

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 import com.picpic.server.common.exception.WsException;
+import com.picpic.server.member.entity.Member;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/StompExceptionHandler.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/StompExceptionHandler.java
@@ -35,7 +35,7 @@ public class StompExceptionHandler extends StompSubProtocolErrorHandler {
 		}
 
 		if(wsException != null) {
-			response.put("type", wsException.getErrorCode());
+			response.put("type", wsException.getErrorCode().getCode());
 			response.put("message", wsException.getMessage());
 		}
 

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/StompExceptionHandler.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/StompExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.picpic.server.common.config.WebSocket.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picpic.server.common.exception.WsException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StompExceptionHandler extends StompSubProtocolErrorHandler {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+		StompHeaderAccessor errorAccessor = StompHeaderAccessor.create(StompCommand.ERROR);
+		errorAccessor.setLeaveMutable(true);
+
+		Map<String, Object> response = new HashMap<>();
+
+		WsException wsException = null;
+
+		Throwable cause = ex.getCause();
+
+		if(cause instanceof WsException) {
+			wsException = (WsException)cause;
+		}
+
+		if(wsException != null) {
+			response.put("type", wsException.getErrorCode());
+			response.put("message", wsException.getMessage());
+		}
+
+		try {
+			byte[] payload = objectMapper.writeValueAsBytes(response);
+
+			return MessageBuilder.createMessage(payload, errorAccessor.getMessageHeaders());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		return super.handleClientMessageProcessingError(clientMessage, ex);
+	}
+}

--- a/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
+++ b/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
@@ -1,0 +1,21 @@
+package com.picpic.server.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WsErrorCode {
+
+	NOT_FOUND_ROOM("1001", "방을 찾을 수 없습니다."),
+	ALREADY_CONNECTED("1002", "이미 연결된 방이 존재합니다."),
+	EXCEED_ROOM_CAPACITY("1003", "방의 인원을 초과하였습니다."),
+	MISSING_MEMBER_INFO("1004", "회원 정보가 누락되었습니다."),
+	USER_NOT_IN_ROOM("1005", "방에 없는 회원입니다."),
+	ACCESS_DENIED_CREATOR_REQUIRED("1006", "방장 권한이 없습니다.");
+
+
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
+++ b/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
@@ -12,8 +12,8 @@ public enum WsErrorCode {
 	EXCEED_ROOM_CAPACITY("1003", "방의 인원을 초과하였습니다."),
 	MISSING_MEMBER_INFO("1004", "회원 정보가 누락되었습니다."),
 	USER_NOT_IN_ROOM("1005", "방에 없는 회원입니다."),
-	ACCESS_DENIED_CREATOR_REQUIRED("1006", "방장 권한이 없습니다.");
-
+	ACCESS_DENIED_CREATOR_REQUIRED("1006", "방장 권한이 없습니다."),
+	NOT_ALL_READY("1007", "아직 준비되지 않은 멤버가 있습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/picpic/server/common/exception/WsException.java
+++ b/src/main/java/com/picpic/server/common/exception/WsException.java
@@ -1,0 +1,14 @@
+package com.picpic.server.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class WsException extends RuntimeException {
+
+	private final WsErrorCode errorCode;
+
+	public WsException(WsErrorCode code) {
+		super(code.getMessage());
+		this.errorCode = code;
+	}
+}

--- a/src/main/java/com/picpic/server/common/exception/WsGlobalExceptionHandler.java
+++ b/src/main/java/com/picpic/server/common/exception/WsGlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.picpic.server.common.exception;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import com.picpic.server.common.response.WsResponse;
+
+@ControllerAdvice
+public class WsGlobalExceptionHandler {
+
+	@MessageExceptionHandler
+	@SendToUser("/queue/errors")
+	public WsResponse<String> handleValidationException(WsException exception) {
+		return WsResponse.error(exception);
+	}
+
+}

--- a/src/main/java/com/picpic/server/common/response/WsResponse.java
+++ b/src/main/java/com/picpic/server/common/response/WsResponse.java
@@ -1,0 +1,28 @@
+package com.picpic.server.common.response;
+
+import com.picpic.server.common.exception.WsException;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WsResponse<T> {
+
+	private String type;
+	private T data;
+
+	public static <T> WsResponse<T> success(String type, T data) {
+		return WsResponse.<T>builder()
+			.type(type)
+			.data(data)
+			.build();
+	}
+
+	public static WsResponse<String> error(WsException exception) {
+		return WsResponse.<String>builder()
+			.type(exception.getErrorCode().getCode())
+			.data(exception.getMessage())
+			.build();
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
+++ b/src/main/java/com/picpic/server/room/controller/CreatePhotoRoomController.java
@@ -1,16 +1,23 @@
 package com.picpic.server.room.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.picpic.server.common.response.ApiResponse;
 import com.picpic.server.common.security.MemberPrincipalDetail;
 import com.picpic.server.room.dto.CreatePhotoRoomRequestDto;
 import com.picpic.server.room.dto.CreatePhotoRoomResponseDto;
 import com.picpic.server.room.service.usecase.CreateRoomUseCase;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -19,22 +26,22 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CreatePhotoRoomController {
 
-    private final CreateRoomUseCase createRoomUseCase;
+	private final CreateRoomUseCase createRoomUseCase;
 
-    @PostMapping("/room")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<CreatePhotoRoomResponseDto> createRoom(
-            @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
-            @Valid @RequestBody CreatePhotoRoomRequestDto request
-    ) {
+	@PostMapping("/room")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<CreatePhotoRoomResponseDto> createRoom(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@Valid @RequestBody CreatePhotoRoomRequestDto request
+	) {
 
-        String createdRoomId = createRoomUseCase.createRoom(memberDetail, request.roomCapacity());
+		String createdRoomId = createRoomUseCase.createRoom(memberDetail, request.roomCapacity());
 
-        CreatePhotoRoomResponseDto response = CreatePhotoRoomResponseDto.builder()
-                .roomId(createdRoomId)
-                .roomCapacity(request.roomCapacity())
-                .build();
+		CreatePhotoRoomResponseDto response = CreatePhotoRoomResponseDto.builder()
+			.roomId(createdRoomId)
+			.roomCapacity(request.roomCapacity())
+			.build();
 
-        return ApiResponse.success(response);
-    }
+		return ApiResponse.success(response);
+	}
 }

--- a/src/main/java/com/picpic/server/room/controller/ws/ChangePageWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/ChangePageWsController.java
@@ -1,0 +1,36 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.ws.ChangePageRequestDto;
+import com.picpic.server.room.dto.ws.ChangePageResponseDto;
+import com.picpic.server.room.service.usecase.ChangePageUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChangePageWsController {
+
+	private final ChangePageUseCase changePageUseCase;
+
+	@MessageMapping("/room/{roomId}/page")
+	@SendTo("/topic/room/{roomId}")
+	public WsResponse<ChangePageResponseDto> update(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId,
+		ChangePageRequestDto request
+	) {
+		changePageUseCase.validate(roomId, memberDetail.memberId());
+
+		return WsResponse.success("CHANGE_PAGE", ChangePageResponseDto.of(request.page()));
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/ws/GetRoomMemberWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/GetRoomMemberWsController.java
@@ -1,36 +1,37 @@
 package com.picpic.server.room.controller.ws;
 
-import com.picpic.server.common.security.MemberPrincipalDetail;
-import com.picpic.server.room.domain.RoomMember;
-import com.picpic.server.room.service.usecase.GetRoomMemberUseCase;
-import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
-import java.util.List;
-import java.util.Set;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.ws.GetRoomMemberWsResponseDto;
+import com.picpic.server.room.service.usecase.GetRoomMemberUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class GetRoomMemberWsController {
 
-    private final GetRoomMemberUseCase getRoomMemberUseCase;
+	private final GetRoomMemberUseCase getRoomMemberUseCase;
 
-    @MessageMapping("/room/{roomId}/members")
-    @SendToUser("/topic/room/members")
-    public List<RoomMember> getRoom(
-            @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
-            @DestinationVariable String roomId
-    ) {
-        List<RoomMember> roomMember = getRoomMemberUseCase.getRoomMember(memberDetail.memberId(), roomId);
+	@MessageMapping("/room/{roomId}/members")
+	@SendToUser("/queue/room")
+	public WsResponse<GetRoomMemberWsResponseDto> getRoom(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId
+	) {
+		List<RoomMember> roomMember = getRoomMemberUseCase.getRoomMember(memberDetail.memberId(), roomId);
 
-        return roomMember;
-    }
+		return WsResponse.success("ROOM_MEMBER_LIST", GetRoomMemberWsResponseDto.from(roomMember));
+	}
 }

--- a/src/main/java/com/picpic/server/room/controller/ws/GetRoomMemberWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/GetRoomMemberWsController.java
@@ -9,7 +9,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
 import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.ws.GetRoomMemberWsResponseDto;
 import com.picpic.server.room.service.usecase.GetRoomMemberUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -23,13 +25,13 @@ public class GetRoomMemberWsController {
 	private final GetRoomMemberUseCase getRoomMemberUseCase;
 
 	@MessageMapping("/room/{roomId}/members")
-	@SendToUser("/topic/room/members")
-	public List<RoomMember> getRoom(
+	@SendToUser("/queue/room")
+	public WsResponse<GetRoomMemberWsResponseDto> getRoom(
 		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
 		@DestinationVariable String roomId
 	) {
 		List<RoomMember> roomMember = getRoomMemberUseCase.getRoomMember(memberDetail.memberId(), roomId);
 
-		return roomMember;
+		return WsResponse.success("ROOM_MEMBER_LIST", GetRoomMemberWsResponseDto.from(roomMember));
 	}
 }

--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateReadyStateWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateReadyStateWsController.java
@@ -1,0 +1,40 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.RoomMemberResponseDto;
+import com.picpic.server.room.dto.ws.UpdateReadyStateRequestDto;
+import com.picpic.server.room.service.usecase.UpdateReadyStateUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UpdateReadyStateWsController {
+
+	private final UpdateReadyStateUseCase updateReadyStateUseCase;
+
+	@MessageMapping("/room/{roomId}/member/state")
+	@SendTo("/topic/room/{roomId}")
+	public WsResponse<RoomMemberResponseDto> update(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId,
+		UpdateReadyStateRequestDto request
+	) {
+
+		RoomMember result = updateReadyStateUseCase.update(roomId, memberDetail.memberId(), request);
+
+		RoomMemberResponseDto response = RoomMemberResponseDto.from(result);
+
+		return WsResponse.success("MEMBER_STATE", response);
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
@@ -1,16 +1,19 @@
 package com.picpic.server.room.controller.ws;
 
-import com.picpic.server.common.security.MemberPrincipalDetail;
-import com.picpic.server.room.dto.ws.RoomCapacityRequestDto;
-import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
-import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.room.dto.ws.RoomCapacityRequestDto;
+import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
+import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Controller
@@ -20,12 +23,18 @@ public class UpdateRoomCapacityWsController {
     private final UpdateRoomCapacityUseCase updateRoomCapacityUseCase;
 
     @MessageMapping("/room/{roomId}/capacity")
-    @SendTo("/topic/room/{roomId}/capacity")
-    public RoomCapacityResponseDto updateRoomCapacity(
+    @SendTo("/topic/room/{roomId}")
+    public WsResponse<RoomCapacityResponseDto> updateRoomCapacity(
             @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
             @DestinationVariable String roomId,
             RoomCapacityRequestDto request
     ) {
-        return updateRoomCapacityUseCase.update(memberDetail.memberId(), roomId, request.roomCapacity());
+        RoomCapacityResponseDto response = updateRoomCapacityUseCase.update(
+            memberDetail.memberId(),
+            roomId,
+            request.roomCapacity()
+        );
+
+        return WsResponse.success("ROOM_CAPACITY", response);
     }
 }

--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateRoomCapacityWsController.java
@@ -6,7 +6,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
-import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
 import com.picpic.server.room.dto.ws.RoomCapacityRequestDto;
 import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
 import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
@@ -14,20 +14,28 @@ import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class UpdateRoomCapacityWsController {
 
-	private final UpdateRoomCapacityUseCase updateRoomCapacityUseCase;
+    private final UpdateRoomCapacityUseCase updateRoomCapacityUseCase;
 
-	@MessageMapping("/room/{roomId}/capacity")
-	@SendTo("/topic/room/{roomId}/capacity")
-	public RoomCapacityResponseDto updateRoomCapacity(
-		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
-		@DestinationVariable String roomId,
-		RoomCapacityRequestDto request
-	) {
-		return updateRoomCapacityUseCase.update(memberDetail.memberId(), roomId, request.roomCapacity());
-	}
+    @MessageMapping("/room/{roomId}/capacity")
+    @SendTo("/topic/room/{roomId}")
+    public WsResponse<RoomCapacityResponseDto> updateRoomCapacity(
+            @AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+            @DestinationVariable String roomId,
+            RoomCapacityRequestDto request
+    ) {
+        RoomCapacityResponseDto response = updateRoomCapacityUseCase.update(
+            memberDetail.memberId(),
+            roomId,
+            request.roomCapacity()
+        );
+
+        return WsResponse.success("ROOM_CAPACITY", response);
+    }
 }

--- a/src/main/java/com/picpic/server/room/domain/RoomMember.java
+++ b/src/main/java/com/picpic/server/room/domain/RoomMember.java
@@ -1,6 +1,7 @@
 package com.picpic.server.room.domain;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.room.enums.RoomMemberStatus;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -13,10 +14,6 @@ public class RoomMember {
 	Long memberId;
 	String memberName;
 	RoomMemberStatus memberStatus;
-
-	public enum RoomMemberStatus {
-		NONE, CONNECTED, DISCONNECTED
-	}
 
 	public static RoomMember from(MemberPrincipalDetail principalDetail) {
 		return RoomMember.builder()

--- a/src/main/java/com/picpic/server/room/dto/GetRoomMemberResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/GetRoomMemberResponseDto.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 @Builder
 public record GetRoomMemberResponseDto(
-        List<RoomMemberDto> members
+        List<RoomMemberResponseDto> members
 ) {
     public static GetRoomMemberResponseDto from(List<RoomMember> roomMembers) {
 
-        List<RoomMemberDto> members = roomMembers.stream().map(RoomMemberDto::from).toList();
+        List<RoomMemberResponseDto> members = roomMembers.stream().map(RoomMemberResponseDto::from).toList();
 
         return GetRoomMemberResponseDto.builder()
                 .members(members)

--- a/src/main/java/com/picpic/server/room/dto/RoomMemberResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/RoomMemberResponseDto.java
@@ -1,22 +1,20 @@
 package com.picpic.server.room.dto;
 
 import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.enums.RoomMemberStatus;
+
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 
 @Builder
-public record RoomMemberDto (
+public record RoomMemberResponseDto(
         String memberName,
         RoomMemberStatus memberStatus
 ) {
-    public enum RoomMemberStatus {
-        CONNECTED, DISCONNECTED
-    }
 
-    public static RoomMemberDto from(RoomMember roomMember) {
-        return RoomMemberDto.builder()
+    public static RoomMemberResponseDto from(RoomMember roomMember) {
+        return RoomMemberResponseDto.builder()
                 .memberName(roomMember.getMemberName())
+                .memberStatus(roomMember.getMemberStatus())
                 .build();
     }
 }

--- a/src/main/java/com/picpic/server/room/dto/ws/ChangePageRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/ChangePageRequestDto.java
@@ -1,0 +1,8 @@
+package com.picpic.server.room.dto.ws;
+
+import com.picpic.server.room.enums.PageEnum;
+
+public record ChangePageRequestDto(
+	PageEnum page
+) {
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/ChangePageResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/ChangePageResponseDto.java
@@ -1,0 +1,16 @@
+package com.picpic.server.room.dto.ws;
+
+import com.picpic.server.room.enums.PageEnum;
+
+import lombok.Builder;
+
+@Builder
+public record ChangePageResponseDto(
+	PageEnum page
+) {
+	public static ChangePageResponseDto of(PageEnum page) {
+		return ChangePageResponseDto.builder()
+			.page(page)
+			.build();
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/GetRoomMemberWsResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/GetRoomMemberWsResponseDto.java
@@ -1,25 +1,21 @@
 package com.picpic.server.room.dto.ws;
 
-import com.picpic.server.room.dto.RoomMemberDto;
-import lombok.Builder;
-
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.RoomMemberDto;
+
+import lombok.Builder;
 
 @Builder
 public record GetRoomMemberWsResponseDto (
         List<RoomMemberDto> members
 ) {
-//    public static GetRoomMemberWsResponseDto from(Set<Object> members) {
-//        members.stream().map(member ->
-//                RoomMemberDto.builder().build();
-//            member instanceof RoomMemberDto ? RoomMemberDto.builder().memberId(member).build(): null
-//        ).toList();
-//
-//
-//        return GetRoomMemberWsResponseDto.builder().members(m).build();
-//    }
+   public static GetRoomMemberWsResponseDto from(List<RoomMember> members) {
+	   List<RoomMemberDto> list = members.stream()
+		   .map(RoomMemberDto::from)
+		   .toList();
+
+	   return GetRoomMemberWsResponseDto.builder().members(list).build();
+   }
 }

--- a/src/main/java/com/picpic/server/room/dto/ws/GetRoomMemberWsResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/GetRoomMemberWsResponseDto.java
@@ -3,17 +3,17 @@ package com.picpic.server.room.dto.ws;
 import java.util.List;
 
 import com.picpic.server.room.domain.RoomMember;
-import com.picpic.server.room.dto.RoomMemberDto;
+import com.picpic.server.room.dto.RoomMemberResponseDto;
 
 import lombok.Builder;
 
 @Builder
 public record GetRoomMemberWsResponseDto (
-        List<RoomMemberDto> members
+        List<RoomMemberResponseDto> members
 ) {
    public static GetRoomMemberWsResponseDto from(List<RoomMember> members) {
-	   List<RoomMemberDto> list = members.stream()
-		   .map(RoomMemberDto::from)
+	   List<RoomMemberResponseDto> list = members.stream()
+		   .map(RoomMemberResponseDto::from)
 		   .toList();
 
 	   return GetRoomMemberWsResponseDto.builder().members(list).build();

--- a/src/main/java/com/picpic/server/room/dto/ws/UpdateReadyStateRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/UpdateReadyStateRequestDto.java
@@ -1,0 +1,9 @@
+package com.picpic.server.room.dto.ws;
+
+public record UpdateReadyStateRequestDto (
+	MemberReadyState memberReadyState
+) {
+	public enum MemberReadyState {
+		READY, NOT_READY
+	}
+}

--- a/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
@@ -1,15 +1,19 @@
 package com.picpic.server.room.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.domain.RoomMember;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Builder(toBuilder = true)
@@ -39,7 +43,7 @@ public class RoomRedisEntity {
         boolean alreadyExists = updatedMembers.stream()
                 .anyMatch(member -> member.getMemberId().equals(newMember.getMemberId()));
         if (alreadyExists) {
-            throw new RuntimeException("User is already in the room. :" + newMember.getMemberId());
+            throw new WsException(WsErrorCode.ALREADY_CONNECTED);
         }
 
         updatedMembers.add(newMember);
@@ -51,7 +55,7 @@ public class RoomRedisEntity {
 
     public RoomRedisEntity subtractMember(Long memberId) {
         if (this.members == null) {
-            throw new RuntimeException("User does not exist in the room. :" + memberId);
+            throw new WsException(WsErrorCode.USER_NOT_IN_ROOM);
         }
 
         List<RoomMember> updatedMembers = this.members.stream()

--- a/src/main/java/com/picpic/server/room/enums/PageEnum.java
+++ b/src/main/java/com/picpic/server/room/enums/PageEnum.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.enums;
+
+public enum PageEnum {
+	SELECT_PAGE
+}

--- a/src/main/java/com/picpic/server/room/enums/RoomMemberStatus.java
+++ b/src/main/java/com/picpic/server/room/enums/RoomMemberStatus.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.enums;
+
+public enum RoomMemberStatus {
+	CONNECTED, DISCONNECTED, READY, NOT_READY
+}

--- a/src/main/java/com/picpic/server/room/service/ChangePageService.java
+++ b/src/main/java/com/picpic/server/room/service/ChangePageService.java
@@ -1,0 +1,47 @@
+package com.picpic.server.room.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.enums.RoomMemberStatus;
+import com.picpic.server.room.service.usecase.ChangePageUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChangePageService implements ChangePageUseCase {
+
+	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+
+	@Override
+	public void validate(String roomId, Long memberId) {
+
+		RoomMember creator = redisRoomQueryUseCase.getCreator(roomId);
+		List<RoomMember> roomMembers = redisRoomQueryUseCase.searchMember(roomId);
+
+		validateCreatorId(memberId, creator);
+		validateAllReadyState(roomMembers);
+	}
+
+	private void validateCreatorId (Long requestMemberId, RoomMember actualCreator) {
+		if(!actualCreator.getMemberId().equals(requestMemberId)) {
+			throw new WsException(WsErrorCode.ACCESS_DENIED_CREATOR_REQUIRED);
+		}
+	}
+
+	private void validateAllReadyState (List<RoomMember> roomMembers) {
+		long count = roomMembers.stream().filter(member ->
+			member.getMemberStatus() != RoomMemberStatus.READY
+		).count();
+
+		if(count > 0) {
+			throw new WsException(WsErrorCode.NOT_ALL_READY);
+		}
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/GetRoomMemberService.java
+++ b/src/main/java/com/picpic/server/room/service/GetRoomMemberService.java
@@ -1,23 +1,21 @@
 package com.picpic.server.room.service;
 
-import com.picpic.server.room.domain.RoomMember;
-import com.picpic.server.room.service.redis.RedisRoomQuery;
-import com.picpic.server.room.service.usecase.GetRoomMemberUseCase;
-import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.service.redis.RedisRoomQuery;
+import com.picpic.server.room.service.usecase.GetRoomMemberUseCase;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GetRoomMemberService implements GetRoomMemberUseCase {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final RedisRoomQueryUseCase redisRomQuery;
     private final RedisRoomQuery redisRoomQuery;
 
     @Override

--- a/src/main/java/com/picpic/server/room/service/UpdateReadyStateService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateReadyStateService.java
@@ -1,0 +1,26 @@
+package com.picpic.server.room.service;
+
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.ws.UpdateReadyStateRequestDto;
+import com.picpic.server.room.enums.RoomMemberStatus;
+import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
+import com.picpic.server.room.service.usecase.UpdateReadyStateUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateReadyStateService implements UpdateReadyStateUseCase {
+
+	private final RedisRoomCommandUseCase redisRoomCommandUseCase;
+
+	@Override
+	public RoomMember update(String roomId, long memberId, UpdateReadyStateRequestDto request) {
+
+		RoomMemberStatus requestState = RoomMemberStatus.valueOf(request.memberReadyState().name());
+
+		return redisRoomCommandUseCase.updateReadyState(roomId, memberId, requestState);
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/UpdateRoomCapacityService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateRoomCapacityService.java
@@ -1,13 +1,17 @@
 package com.picpic.server.room.service;
 
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.domain.RoomMember;
 import com.picpic.server.room.dto.ws.RoomCapacityResponseDto;
 import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
 import com.picpic.server.room.service.usecase.UpdateRoomCapacityUseCase;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -35,7 +39,7 @@ public class UpdateRoomCapacityService implements UpdateRoomCapacityUseCase {
 
     private void validateCreatorId (Long requestMemberId, RoomMember actualCreator) {
         if(!actualCreator.getMemberId().equals(requestMemberId)) {
-            throw new RuntimeException("Access denied. Room creator privileges required.");
+            throw new WsException(WsErrorCode.ACCESS_DENIED_CREATOR_REQUIRED);
         }
     }
 
@@ -43,7 +47,7 @@ public class UpdateRoomCapacityService implements UpdateRoomCapacityUseCase {
         int currentRoomMemberSize = redisRoomQueryUseCase.searchMember(roomId).size();
 
         if(currentRoomMemberSize > roomCapacity ) {
-            throw new RuntimeException("Current room member capacity is greater than requested room capacity.");
+            throw new WsException(WsErrorCode.EXCEED_ROOM_CAPACITY);
         }
     }
 }

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -1,12 +1,16 @@
 package com.picpic.server.room.service.redis;
 
+import org.springframework.stereotype.Component;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.common.security.MemberPrincipalDetail;
 import com.picpic.server.room.domain.RoomMember;
 import com.picpic.server.room.entity.RoomRedisEntity;
 import com.picpic.server.room.repository.RoomRedisRepository;
 import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -34,7 +38,7 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
     @Override
     public void addMember(String roomId, MemberPrincipalDetail memberPrincipalDetail) {
         RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
         RoomMember newMember = RoomMember.from(memberPrincipalDetail);
         RoomRedisEntity updatedEntity = roomEntity.addMember(newMember);
@@ -45,7 +49,7 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
     @Override
     public void subtractMember(String roomId, Long memberId) {
         RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
         RoomRedisEntity updatedEntity = roomEntity.subtractMember(memberId);
 
@@ -55,7 +59,7 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
     @Override
     public void updateRoomCapacity(String roomId, Integer roomCapacity) {
         RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
         RoomRedisEntity updatedRoom = roomEntity.toBuilder()
                 .roomCapacity(roomCapacity)

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -1,5 +1,7 @@
 package com.picpic.server.room.service.redis;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
@@ -8,6 +10,7 @@ import com.picpic.server.common.exception.WsErrorCode;
 import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.domain.RoomMember;
 import com.picpic.server.room.entity.RoomRedisEntity;
+import com.picpic.server.room.enums.RoomMemberStatus;
 import com.picpic.server.room.repository.RoomRedisRepository;
 import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
 
@@ -67,5 +70,32 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 			.build();
 
 		roomRedisRepository.save(updatedRoom);
+	}
+
+	@Override
+	public RoomMember updateReadyState(String roomId, Long memberId, RoomMemberStatus roomMemberStatus) {
+
+		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+			.orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
+
+		List<RoomMember> updatedMembers = roomEntity.getMembers().stream().map(member -> {
+			if (member.getMemberId().equals(memberId)) {
+				member.setMemberStatus(roomMemberStatus);
+			}
+			return member;
+		}).toList();
+
+		RoomRedisEntity updatedRoomEntity = roomEntity.toBuilder()
+			.members(updatedMembers)
+			.build();
+
+		RoomRedisEntity save = roomRedisRepository.save(updatedRoomEntity);
+
+		RoomMember roomMember = save.getMembers().stream()
+			.filter(member -> member.getMemberId().equals(memberId))
+			.findFirst()
+			.get();
+
+		return roomMember;
 	}
 }

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -3,6 +3,9 @@ package com.picpic.server.room.service.redis;
 import org.springframework.stereotype.Component;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.domain.RoomMember;
 import com.picpic.server.room.entity.RoomRedisEntity;
 import com.picpic.server.room.repository.RoomRedisRepository;
@@ -33,10 +36,10 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 		roomRedisRepository.deleteById(roomId);
 	}
 
-	@Override
-	public void addMember(String roomId, MemberPrincipalDetail memberPrincipalDetail) {
-		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-			.orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+    @Override
+    public void addMember(String roomId, MemberPrincipalDetail memberPrincipalDetail) {
+        RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
 		RoomMember newMember = RoomMember.from(memberPrincipalDetail);
 		RoomRedisEntity updatedEntity = roomEntity.addMember(newMember);
@@ -44,20 +47,20 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 		roomRedisRepository.save(updatedEntity);
 	}
 
-	@Override
-	public void subtractMember(String roomId, Long memberId) {
-		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-			.orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+    @Override
+    public void subtractMember(String roomId, Long memberId) {
+        RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
 		RoomRedisEntity updatedEntity = roomEntity.subtractMember(memberId);
 
 		roomRedisRepository.save(updatedEntity);
 	}
 
-	@Override
-	public void updateRoomCapacity(String roomId, Integer roomCapacity) {
-		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
-			.orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+    @Override
+    public void updateRoomCapacity(String roomId, Integer roomCapacity) {
+        RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
 		RoomRedisEntity updatedRoom = roomEntity.toBuilder()
 			.roomCapacity(roomCapacity)

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomQuery.java
@@ -1,13 +1,17 @@
 package com.picpic.server.room.service.redis;
 
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
 import com.picpic.server.room.domain.RoomMember;
 import com.picpic.server.room.entity.RoomRedisEntity;
 import com.picpic.server.room.repository.RoomRedisRepository;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -18,7 +22,7 @@ public class RedisRoomQuery implements RedisRoomQueryUseCase {
     @Override
     public List<RoomMember> searchMember(String roomId) {
         return roomRedisRepository.findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId))
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM))
                 .getMembers();
     }
 
@@ -32,7 +36,7 @@ public class RedisRoomQuery implements RedisRoomQueryUseCase {
 
         RoomRedisEntity roomRedisEntity = roomRedisRepository
                 .findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
 
         return roomRedisEntity.getRoomCapacity();
     }
@@ -42,7 +46,8 @@ public class RedisRoomQuery implements RedisRoomQueryUseCase {
 
         RoomRedisEntity roomRedisEntity = roomRedisRepository
                 .findById(roomId)
-                .orElseThrow(() -> new RuntimeException("Room not found. :" + roomId));
+                .orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
+
 
         return roomRedisEntity.getCreator();
     }

--- a/src/main/java/com/picpic/server/room/service/usecase/ChangePageUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/ChangePageUseCase.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.service.usecase;
+
+public interface ChangePageUseCase {
+	void validate(String roomId, Long memberId);
+}

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
@@ -1,6 +1,8 @@
 package com.picpic.server.room.service.usecase;
 
 import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.enums.RoomMemberStatus;
 
 public interface RedisRoomCommandUseCase {
 	void create(String roomId, MemberPrincipalDetail memberPrincipal, Integer roomCapacity);
@@ -12,4 +14,6 @@ public interface RedisRoomCommandUseCase {
 	void subtractMember(String roomId, Long memberId);
 
 	void updateRoomCapacity(String roomId, Integer roomCapacity);
+
+	RoomMember updateReadyState(String roomId, Long memberId, RoomMemberStatus roomMemberStatus);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/UpdateReadyStateUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/UpdateReadyStateUseCase.java
@@ -1,0 +1,8 @@
+package com.picpic.server.room.service.usecase;
+
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.dto.ws.UpdateReadyStateRequestDto;
+
+public interface UpdateReadyStateUseCase {
+	RoomMember update(String roomId, long memberId, UpdateReadyStateRequestDto request);
+}


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 멤버 준비 상태 업데이트 web socket 추가
- 전체 멤버 준비 완료 후, 페이지 전환 브로드캐스트 추가
  - 방장 권한 검증 추가
  - 모든 멤버가 준비완료된 상태인지 검증 추가


## 📸 스크린샷 (선택)
<!-- UI 작업 등 눈에 보이는 변경사항이 있다면 첨부해주세요 -->
1. 준비되지 않는 멤버가 있을 경우 에러 응답
<img width="390" height="29" alt="image" src="https://github.com/user-attachments/assets/b6f2328a-8006-4d9a-b01e-dd8c6c47b863" />

2. 방장이 아닌 멤버가 요청할 경우 에러 응답
<img width="330" height="22" alt="image" src="https://github.com/user-attachments/assets/e2382b62-0506-42e1-8b51-5af7df2a35f4" />

3. 요청 성공 시, 모든 멤버에게 페이지 변경에 대한 응답을 브로드캐스트
<img width="424" height="39" alt="image" src="https://github.com/user-attachments/assets/7f62035a-515e-45ad-a984-f1b6e2f7f4e5" />

