### PR TITLE
feat/#46: 프레임 도메인 생성

### DIFF
--- a/src/main/java/com/picpic/server/frame/controller/FrameOptionController.java
+++ b/src/main/java/com/picpic/server/frame/controller/FrameOptionController.java
@@ -1,0 +1,29 @@
+package com.picpic.server.frame.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.picpic.server.frame.dto.FrameOptionResponse;
+import com.picpic.server.frame.service.FrameOptionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/room/{roomId}/frames")
+@RequiredArgsConstructor
+public class FrameOptionController {
+	private final FrameOptionService frameOptionService;
+
+	@GetMapping
+	public ResponseEntity<List<FrameOptionResponse>> getFrameOptions(
+		@PathVariable Long roomId  // 추후 roomId 기반 필터링 로직 추가 예정
+	) {
+		List<FrameOptionResponse> options = frameOptionService.getAllFrameOptions();
+		return ResponseEntity.ok(options);
+	}
+}

--- a/src/main/java/com/picpic/server/frame/dto/FrameOptionResponse.java
+++ b/src/main/java/com/picpic/server/frame/dto/FrameOptionResponse.java
@@ -1,0 +1,9 @@
+package com.picpic.server.frame.dto;
+
+public record FrameOptionResponse(
+	Long frameId,
+	String name,
+	Integer slotCount,
+	String frameImageUrl
+) {
+}

--- a/src/main/java/com/picpic/server/frame/entity/Frame.java
+++ b/src/main/java/com/picpic/server/frame/entity/Frame.java
@@ -1,0 +1,54 @@
+package com.picpic.server.frame.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "frame")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Frame {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "frame_id")
+	private Long frameId;
+
+	@Column(nullable = false, length = 20)
+	private String name;
+
+	@Column(name = "slot_count", nullable = false)
+	private Integer slotCount;
+
+	@Column(name = "frame_image_url", nullable = false)
+	private String frameImageUrl;
+
+	@CreationTimestamp
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+}
+

--- a/src/main/java/com/picpic/server/frame/repository/FrameRepository.java
+++ b/src/main/java/com/picpic/server/frame/repository/FrameRepository.java
@@ -1,0 +1,11 @@
+package com.picpic.server.frame.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.picpic.server.frame.entity.Frame;
+
+public interface FrameRepository extends JpaRepository<Frame, Long> {
+	List<Frame> findByDeletedAtIsNull();
+}

--- a/src/main/java/com/picpic/server/frame/service/FrameOptionService.java
+++ b/src/main/java/com/picpic/server/frame/service/FrameOptionService.java
@@ -1,0 +1,30 @@
+package com.picpic.server.frame.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.picpic.server.frame.dto.FrameOptionResponse;
+import com.picpic.server.frame.repository.FrameRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FrameOptionService {
+
+	private final FrameRepository frameRepository;
+
+	@Transactional(readOnly = true)
+	public List<FrameOptionResponse> getAllFrameOptions() {
+		return frameRepository.findByDeletedAtIsNull().stream()
+			.map(frame -> new FrameOptionResponse(
+				frame.getFrameId(),
+				frame.getName(),
+				frame.getSlotCount(),
+				frame.getFrameImageUrl()
+			))
+			.toList();
+	}
+}

--- a/src/main/java/com/picpic/server/photo/controller/PhotoController.java
+++ b/src/main/java/com/picpic/server/photo/controller/PhotoController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.common.auth.MemberPrincipalDetail;
 import com.picpic.server.photo.dto.PhotoDetailResponse;
 import com.picpic.server.photo.dto.PhotoListResponse;
 import com.picpic.server.photo.service.usecase.PhotoUseCase;

--- a/src/test/java/com/picpic/server/frame/controller/FrameOptionControllerTest.java
+++ b/src/test/java/com/picpic/server/frame/controller/FrameOptionControllerTest.java
@@ -1,0 +1,58 @@
+package com.picpic.server.frame.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picpic.server.frame.dto.FrameOptionResponse;
+import com.picpic.server.frame.service.FrameOptionService;
+
+@WebMvcTest(FrameOptionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FrameOptionControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private FrameOptionService frameOptionService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("GET /api/room/{roomId}/frames - 200, 리스트 반환")
+	void getFrameOptions_success() throws Exception {
+		// given
+		Long roomId = 42L;
+		List<FrameOptionResponse> mockList = List.of(
+			new FrameOptionResponse(1L, "2x2", 4, "url1"),
+			new FrameOptionResponse(2L, "1x4", 4, "url2")
+		);
+		given(frameOptionService.getAllFrameOptions()).willReturn(mockList);
+
+		// when & then
+		mockMvc.perform(get("/api/room/{roomId}/frames", roomId)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.length()").value(2))
+			.andExpect(jsonPath("$[0].frameId").value(1))
+			.andExpect(jsonPath("$[0].name").value("2x2"))
+			.andExpect(jsonPath("$[1].frameImageUrl").value("url2"));
+
+		then(frameOptionService).should().getAllFrameOptions();
+	}
+}

--- a/src/test/java/com/picpic/server/frame/service/FrameOptionServiceTest.java
+++ b/src/test/java/com/picpic/server/frame/service/FrameOptionServiceTest.java
@@ -1,0 +1,70 @@
+package com.picpic.server.frame.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.picpic.server.frame.dto.FrameOptionResponse;
+import com.picpic.server.frame.entity.Frame;
+import com.picpic.server.frame.repository.FrameRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FrameOptionServiceTest {
+
+	@Mock
+	private FrameRepository frameRepository;
+
+	@InjectMocks
+	private FrameOptionService frameOptionService;
+
+	@Test
+	@DisplayName("활성화된 프레임만 조회해서 DTO로 매핑한다")
+	void getAllFrameOptions_filtersDeletedAndMapsToDto() {
+		Frame active1 = Frame.builder()
+			.frameId(1L)
+			.name("2x2")
+			.slotCount(4)
+			.frameImageUrl("url1")
+			.deletedAt(null)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		Frame active2 = Frame.builder()
+			.frameId(2L)
+			.name("1x4")
+			.slotCount(4)
+			.frameImageUrl("url2")
+			.deletedAt(null)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		given(frameRepository.findByDeletedAtIsNull())
+			.willReturn(List.of(active1, active2));
+
+		List<FrameOptionResponse> result = frameOptionService.getAllFrameOptions();
+
+		then(frameRepository).should().findByDeletedAtIsNull();
+		assertThat(result).hasSize(2);
+
+		FrameOptionResponse dto1 = result.get(0);
+		assertThat(dto1.frameId()).isEqualTo(1L);
+		assertThat(dto1.name()).isEqualTo("2x2");
+		assertThat(dto1.slotCount()).isEqualTo(4);
+		assertThat(dto1.frameImageUrl()).isEqualTo("url1");
+
+		FrameOptionResponse dto2 = result.get(1);
+		assertThat(dto2.frameId()).isEqualTo(2L);
+		assertThat(dto2.name()).isEqualTo("1x4");
+		assertThat(dto2.slotCount()).isEqualTo(4);
+		assertThat(dto2.frameImageUrl()).isEqualTo("url2");
+	}
+}

--- a/src/test/java/com/picpic/server/photo/controller/PhotoControllerTest.java
+++ b/src/test/java/com/picpic/server/photo/controller/PhotoControllerTest.java
@@ -16,7 +16,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.picpic.server.common.security.MemberPrincipalDetail;
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.member.entity.Member;
 import com.picpic.server.photo.dto.PhotoDetailResponse;
 import com.picpic.server.photo.dto.PhotoListResponse;
 import com.picpic.server.photo.service.usecase.PhotoUseCase;
@@ -34,8 +35,12 @@ class PhotoControllerTest {
 	 * MemberPrincipalDetail 을 Authentication 토큰에 담아 주입하는 헬퍼
 	 */
 	private Authentication auth(long memberId) {
-		// record 생성자를 직접 사용합니다.
-		MemberPrincipalDetail principal = new MemberPrincipalDetail(memberId, "nick" + memberId);
+
+		MemberPrincipalDetail principal = new MemberPrincipalDetail(
+			memberId,
+			"nick" + memberId,
+			Member.Role.GUEST
+		);
 		return new UsernamePasswordAuthenticationToken(principal, null, List.of());
 	}
 


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- frame 도메인 생성
- FrameOptionControllerTest, FrameOptionServiceTest (단위 테스트)
- PhotoTest에서 MemberPrincipalDetail의 형태와 경로 변경
- PhotoController에서 MemberPrincipalDetail의 경로 변경


## 📸 스크린샷 (선택)
<!-- UI 작업 등 눈에 보이는 변경사항이 있다면 첨부해주세요 -->



## 📝 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요 -->
- 
