### PR TITLE
feat/#59: add websocket to update background websocket

### DIFF
--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateBackgroundWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateBackgroundWsController.java
@@ -1,0 +1,39 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.ws.UpdateBackgroundRequestDto;
+import com.picpic.server.room.dto.ws.UpdateBackgroundResponseDto;
+import com.picpic.server.room.service.usecase.UpdateBackgroundUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UpdateBackgroundWsController {
+
+	private final UpdateBackgroundUseCase updateBackgroundUseCase;
+
+	@MessageMapping("/room/{roomId}/background")
+	@SendTo("/topic/room/{roomId}")
+	public WsResponse<UpdateBackgroundResponseDto> updateBackground(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId,
+		UpdateBackgroundRequestDto request
+	) {
+		Integer update = updateBackgroundUseCase.update(
+			roomId,
+			memberDetail.memberId(),
+			request.backgroundId());
+
+		return WsResponse.success("UPDATE_BACKGROUND", UpdateBackgroundResponseDto.of(update));
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundRequestDto.java
@@ -1,0 +1,6 @@
+package com.picpic.server.room.dto.ws;
+
+public record UpdateBackgroundRequestDto(
+	Integer backgroundId
+) {
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundResponseDto.java
@@ -1,0 +1,10 @@
+package com.picpic.server.room.dto.ws;
+
+
+public record UpdateBackgroundResponseDto(
+	Integer backgroundId
+) {
+	public static UpdateBackgroundResponseDto of(Integer backgroundId) {
+		return new UpdateBackgroundResponseDto(backgroundId);
+	}
+}

--- a/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
@@ -33,6 +33,8 @@ public class RoomRedisEntity {
     @Builder.Default
     private int roomCapacity = 6;
 
+    private int backgroundId;
+
     public RoomRedisEntity addMember(RoomMember newMember) {
 
         List<RoomMember> updatedMembers = new ArrayList<>();

--- a/src/main/java/com/picpic/server/room/service/UpdateBackgroundService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateBackgroundService.java
@@ -1,0 +1,36 @@
+package com.picpic.server.room.service;
+
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+import com.picpic.server.room.service.usecase.UpdateBackgroundUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateBackgroundService implements UpdateBackgroundUseCase {
+
+	private final RedisRoomCommandUseCase redisRoomCommandUseCase;
+	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+
+	@Override
+	public Integer update(String roomId, Long memberId, Integer backgroundId) {
+
+		RoomMember creator = redisRoomQueryUseCase.getCreator(roomId);
+
+		validateCreatorId(memberId, creator);
+
+		return redisRoomCommandUseCase.updateBackground(roomId, backgroundId);
+	}
+
+	private void validateCreatorId (Long requestMemberId, RoomMember actualCreator) {
+		if(!actualCreator.getMemberId().equals(requestMemberId)) {
+			throw new WsException(WsErrorCode.ACCESS_DENIED_CREATOR_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -98,4 +98,19 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 
 		return roomMember;
 	}
+
+	@Override
+	public int updateBackground(String roomId, Integer backgroundId) {
+
+		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+			.orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
+
+		RoomRedisEntity updated = roomEntity.toBuilder()
+			.backgroundId(backgroundId)
+			.build();
+
+		RoomRedisEntity save = roomRedisRepository.save(updated);
+
+		return save.getBackgroundId();
+	}
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
@@ -16,4 +16,6 @@ public interface RedisRoomCommandUseCase {
 	void updateRoomCapacity(String roomId, Integer roomCapacity);
 
 	RoomMember updateReadyState(String roomId, Long memberId, RoomMemberStatus roomMemberStatus);
+
+	int updateBackground(String roomId, Integer backgroundId);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/UpdateBackgroundUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/UpdateBackgroundUseCase.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.service.usecase;
+
+public interface UpdateBackgroundUseCase {
+	Integer update(String roomId, Long memberId, Integer backgroundId);
+}


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 배경 업데이트 웹소켓 컨트롤러 추가
  - 권한 검증 : 방 생성자가 아닌 멤버가 요청을 보낼 경우, 에러 응답


## 📸 스크린샷 (선택)
<!-- UI 작업 등 눈에 보이는 변경사항이 있다면 첨부해주세요 -->
1. 성공 시 응답
<img width="476" height="31" alt="image" src="https://github.com/user-attachments/assets/d2b3c50d-c26a-4d6f-928d-8fa2f6f6cd0d" />

2. 방생성자가 아닌 멤버가 요청시 에러 응답
<img width="312" height="22" alt="image" src="https://github.com/user-attachments/assets/095943c0-c4d1-4892-8c3b-59b58e2d60c2" />
