### PR TITLE
Feat/#63/support to jwt in ws interceptor

### DIFF
--- a/src/main/java/com/picpic/server/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/picpic/server/common/auth/JwtAuthenticationFilter.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		String token = jwtTokenProvider.resolveToken(request);
+		String token = jwtTokenProvider.resolveToken(request.getHeader("Authorization"));
 
 		if (token == null) {
 			throw new ApiException(ErrorCode.UNAUTHORIZED);
@@ -59,7 +59,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			path.startsWith("/h2") ||
 				path.startsWith("/api/v1/sign-in") ||
 				path.startsWith("/api/v1/sign-up") ||
-				path.startsWith("/api/v1/guest");
+				path.startsWith("/api/v1/guest") ||
+				path.startsWith("/wss");
 	}
 
 }

--- a/src/main/java/com/picpic/server/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/picpic/server/common/auth/JwtTokenProvider.java
@@ -98,9 +98,7 @@ public class JwtTokenProvider {
 		return new SecretKeySpec(bytes, "HmacSHA256");
 	}
 
-	public String resolveToken(HttpServletRequest request) {
-		String authorizationHeader = request.getHeader("Authorization");
-
+	public String resolveToken(String authorizationHeader) {
 		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
 			return null;
 		}

--- a/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
+++ b/src/main/java/com/picpic/server/common/config/WebSocket/interceptor/RoomValidationInterceptor.java
@@ -12,6 +12,9 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import com.picpic.server.common.auth.JwtTokenProvider;
+import com.picpic.server.common.exception.ApiException;
+import com.picpic.server.common.exception.ErrorCode;
 import com.picpic.server.common.exception.WsException;
 import com.picpic.server.member.entity.Member;
 import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
@@ -28,6 +31,7 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
 
 	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -35,32 +39,39 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
 		StompCommand command = accessor.getCommand();
 
         if (StompCommand.CONNECT.equals(command)) {
-            // TODO: Jwt 유틸 개발 이후, 이 부분에 토큰 안에 담긴 내용으로 principal 생성해야함
-//            String token = accessor.getFirstNativeHeader("Authorization");
-            String token = accessor.getFirstNativeHeader("X-Test-Member-Id");
+           	String token = accessor.getFirstNativeHeader("Authorization");
             String roomId = accessor.getFirstNativeHeader("roomId");
+
+			token = jwtTokenProvider.resolveToken(token);
 
 			if (token == null || roomId == null) {
 				log.warn("[STOMP] CONNECT rejected - Missing token or roomId");
 				return null;
 			}
 
-            try {
-                validateAlreadyEnter(token);
-                validateRoomExist(roomId);
-                validateRoomCapacity(roomId);
+			try {
+				validateToken(token);
+
+				String userId = String.valueOf(jwtTokenProvider.getMemberId(token));
+				String nickname = jwtTokenProvider.getNickname(token);
+				Member.Role role = jwtTokenProvider.getRole(token);
+
+				validateAlreadyEnter(userId);
+				validateRoomExist(roomId);
+				validateRoomCapacity(roomId);
 
 				MemberPrincipalDetail principal = new MemberPrincipalDetail(
-					Long.parseLong(token),
-					"test nickname",
-					Member.Role.GUEST
+					Long.parseLong(userId),
+					nickname,
+					role
 				);
 
                 accessor.setUser(principal);
 
-                log.info("[STOMP] CONNECT approved - userId: {}, roomId: {}", token, roomId);
-            } catch (WsException e) {
-                throw new MessagingException(e.getMessage(), e);
+                log.info("[STOMP] CONNECT approved - userId: {}, roomId: {}", userId, roomId);
+            }  catch (WsException e) {
+                log.error("[STOMP] CONNECT failed: {}", e.getMessage(), e);
+				throw new MessagingException(e.getMessage(), e);
             }
         }
 
@@ -88,4 +99,17 @@ public class RoomValidationInterceptor implements ChannelInterceptor {
             throw new WsException(EXCEED_ROOM_CAPACITY);
         }
     }
+
+	private void validateToken(String token) {
+		try {
+			jwtTokenProvider.validateToken(token);
+		} catch (ApiException e) {
+			if(e.getErrorCode() == ErrorCode.EXPIRED_TOKEN) {
+				throw new WsException(EXPIRED_TOKEN);
+			}
+			if(e.getErrorCode() == ErrorCode.UNAVAILABLE_TOKEN) {
+				throw new WsException(UNAVAILABLE_TOKEN);
+			}
+		}
+	}
 }

--- a/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
+++ b/src/main/java/com/picpic/server/common/exception/WsErrorCode.java
@@ -7,13 +7,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WsErrorCode {
 
-	NOT_FOUND_ROOM("1001", "방을 찾을 수 없습니다."),
-	ALREADY_CONNECTED("1002", "이미 연결된 방이 존재합니다."),
-	EXCEED_ROOM_CAPACITY("1003", "방의 인원을 초과하였습니다."),
-	MISSING_MEMBER_INFO("1004", "회원 정보가 누락되었습니다."),
-	USER_NOT_IN_ROOM("1005", "방에 없는 회원입니다."),
-	ACCESS_DENIED_CREATOR_REQUIRED("1006", "방장 권한이 없습니다."),
-	NOT_ALL_READY("1007", "아직 준비되지 않은 멤버가 있습니다.");
+	NOT_FOUND_ROOM("WS1001", "방을 찾을 수 없습니다."),
+	ALREADY_CONNECTED("WS1002", "이미 연결된 방이 존재합니다."),
+	EXCEED_ROOM_CAPACITY("WS1003", "방의 인원을 초과하였습니다."),
+	MISSING_MEMBER_INFO("WS1004", "회원 정보가 누락되었습니다."),
+	USER_NOT_IN_ROOM("WS1005", "방에 없는 회원입니다."),
+	ACCESS_DENIED_CREATOR_REQUIRED("WS1006", "방장 권한이 없습니다."),
+	NOT_ALL_READY("WS1007", "아직 준비되지 않은 멤버가 있습니다."),
+	UNAVAILABLE_TOKEN("WS1008", "유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN("WS1009", "토큰이 만료됐습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/picpic/server/room/controller/ws/UpdateBackgroundWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/UpdateBackgroundWsController.java
@@ -1,0 +1,39 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.ws.UpdateBackgroundRequestDto;
+import com.picpic.server.room.dto.ws.UpdateBackgroundResponseDto;
+import com.picpic.server.room.service.usecase.UpdateBackgroundUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UpdateBackgroundWsController {
+
+	private final UpdateBackgroundUseCase updateBackgroundUseCase;
+
+	@MessageMapping("/room/{roomId}/background")
+	@SendTo("/topic/room/{roomId}")
+	public WsResponse<UpdateBackgroundResponseDto> updateBackground(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId,
+		UpdateBackgroundRequestDto request
+	) {
+		Integer update = updateBackgroundUseCase.update(
+			roomId,
+			memberDetail.memberId(),
+			request.backgroundId());
+
+		return WsResponse.success("UPDATE_BACKGROUND", UpdateBackgroundResponseDto.of(update));
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundRequestDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundRequestDto.java
@@ -1,0 +1,6 @@
+package com.picpic.server.room.dto.ws;
+
+public record UpdateBackgroundRequestDto(
+	Integer backgroundId
+) {
+}

--- a/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/ws/UpdateBackgroundResponseDto.java
@@ -1,0 +1,10 @@
+package com.picpic.server.room.dto.ws;
+
+
+public record UpdateBackgroundResponseDto(
+	Integer backgroundId
+) {
+	public static UpdateBackgroundResponseDto of(Integer backgroundId) {
+		return new UpdateBackgroundResponseDto(backgroundId);
+	}
+}

--- a/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
+++ b/src/main/java/com/picpic/server/room/entity/RoomRedisEntity.java
@@ -33,6 +33,8 @@ public class RoomRedisEntity {
     @Builder.Default
     private int roomCapacity = 6;
 
+    private int backgroundId;
+
     public RoomRedisEntity addMember(RoomMember newMember) {
 
         List<RoomMember> updatedMembers = new ArrayList<>();

--- a/src/main/java/com/picpic/server/room/service/UpdateBackgroundService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateBackgroundService.java
@@ -1,0 +1,36 @@
+package com.picpic.server.room.service;
+
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.service.usecase.RedisRoomCommandUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+import com.picpic.server.room.service.usecase.UpdateBackgroundUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateBackgroundService implements UpdateBackgroundUseCase {
+
+	private final RedisRoomCommandUseCase redisRoomCommandUseCase;
+	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+
+	@Override
+	public Integer update(String roomId, Long memberId, Integer backgroundId) {
+
+		RoomMember creator = redisRoomQueryUseCase.getCreator(roomId);
+
+		validateCreatorId(memberId, creator);
+
+		return redisRoomCommandUseCase.updateBackground(roomId, backgroundId);
+	}
+
+	private void validateCreatorId (Long requestMemberId, RoomMember actualCreator) {
+		if(!actualCreator.getMemberId().equals(requestMemberId)) {
+			throw new WsException(WsErrorCode.ACCESS_DENIED_CREATOR_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
+++ b/src/main/java/com/picpic/server/room/service/redis/RedisRoomCommand.java
@@ -98,4 +98,19 @@ public class RedisRoomCommand implements RedisRoomCommandUseCase {
 
 		return roomMember;
 	}
+
+	@Override
+	public int updateBackground(String roomId, Integer backgroundId) {
+
+		RoomRedisEntity roomEntity = roomRedisRepository.findById(roomId)
+			.orElseThrow(() -> new WsException(WsErrorCode.NOT_FOUND_ROOM));
+
+		RoomRedisEntity updated = roomEntity.toBuilder()
+			.backgroundId(backgroundId)
+			.build();
+
+		RoomRedisEntity save = roomRedisRepository.save(updated);
+
+		return save.getBackgroundId();
+	}
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/RedisRoomCommandUseCase.java
@@ -16,4 +16,6 @@ public interface RedisRoomCommandUseCase {
 	void updateRoomCapacity(String roomId, Integer roomCapacity);
 
 	RoomMember updateReadyState(String roomId, Long memberId, RoomMemberStatus roomMemberStatus);
+
+	int updateBackground(String roomId, Integer backgroundId);
 }

--- a/src/main/java/com/picpic/server/room/service/usecase/UpdateBackgroundUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/UpdateBackgroundUseCase.java
@@ -1,0 +1,5 @@
+package com.picpic.server.room.service.usecase;
+
+public interface UpdateBackgroundUseCase {
+	Integer update(String roomId, Long memberId, Integer backgroundId);
+}


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 기존 WebSocket Interceptor 중 connection 주기에서 JWT Token을 추가

## 주요 변경사항
1. `JwtTokenProvider`의 `resolveToken`의 파라미터 타입을 HttpServletRequest에서 String로 변경
  - `resolveToken` 함수를 WS Interceptor에서도 사용하기 위해, 타입을 변경

2. `JwtAuthenticationFilter`의 `shouldNotFilter`에 `path.startsWith("/wss")` 추가
  - 이유: SockJS에서 HandShake 과정에서 Header를 사용할 수 없으므로, Filter에서 웹 소켓 관련 path는 제외함.
  - Jwt 검증은 Filter 이후 Interceptor에서 처리하도록 변경

  - 관련 참고 내용
    - https://github.com/sockjs/sockjs-client/issues/196
