### PR TITLE
Feat/#65/add webrtc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("com.github.f4b6a3:tsid-creator:5.2.6")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.openvidu:openvidu-java-client:2.31.0")
     testImplementation("org.springframework.security:spring-security-test")
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,3 +24,16 @@ services:
     volumes:
       - ./mysql/data:/var/lib/mysql
       - ./mysql/init:/docker-entrypoint-initdb.d
+  openvidu_container:
+    image: openvidu/openvidu-dev:2.28.0
+    ports:
+      - "4443:4443"
+    environment:
+      - OPENVIDU_SECRET=${OPEN_VIDU_SECRET}
+      - DOMAIN_OR_PUBLIC_IP=localhost
+      - OPENVIDU_WEBHOOK=true
+      - OPENVIDU_WEBHOOK_ENDPOINT=http://host.docker.internal:8080/api/webhooks/openvidu
+      - OPENVIDU_WEBHOOK_EVENTS=["participantJoined","participantLeft"]
+      - "OPENVIDU_WEBHOOK_HEADERS=[\"Authorization: ${OPEN_VIDU_TOKEN}\"]"
+      - OPENVIDU_RECORDING=false
+      - OPENVIDU_CDR=false

--- a/src/main/java/com/picpic/server/common/auth/SecurityConfig.java
+++ b/src/main/java/com/picpic/server/common/auth/SecurityConfig.java
@@ -64,7 +64,9 @@ public class SecurityConfig {
 
 		configuration.setAllowedOrigins(Arrays.asList(
 			"http://localhost:5173",
-			"https://localhost:5173"
+			"https://localhost:5173",
+			"http://127.0.0.1:4443",
+			"http://localhost:4443"
 		));
 
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/src/main/java/com/picpic/server/common/config/OpenViduConfig/OpenViduConfig.java
+++ b/src/main/java/com/picpic/server/common/config/OpenViduConfig/OpenViduConfig.java
@@ -1,0 +1,22 @@
+package com.picpic.server.common.config.OpenViduConfig;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.openvidu.java.client.OpenVidu;
+
+@Configuration
+public class OpenViduConfig {
+
+	@Value("${OPENVIDU_URL}")
+	private String OPENVIDU_URL;
+
+	@Value("${OPENVIDU_SECRET}")
+	private String OPENVIDU_SECRET;
+
+	@Bean
+	public OpenVidu openvidu() {
+		return new OpenVidu(OPENVIDU_URL, OPENVIDU_SECRET);
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/OpenviduWebHook.java
+++ b/src/main/java/com/picpic/server/room/controller/OpenviduWebHook.java
@@ -1,0 +1,26 @@
+package com.picpic.server.room.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.picpic.server.room.service.usecase.UpdateOVMemberStateUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/webhooks/openvidu")
+@RequiredArgsConstructor
+public class OpenviduWebHook {
+
+	private final UpdateOVMemberStateUseCase updateOVMemberStateUseCase;
+
+	@PostMapping
+	public void webhookTest(@RequestBody String payload) throws JsonProcessingException {
+		updateOVMemberStateUseCase.updateMemberState(payload);
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/ws/CreateWebRtcRoomWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/CreateWebRtcRoomWsController.java
@@ -1,0 +1,36 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.CreateRtcRoomResponseDto;
+import com.picpic.server.room.service.usecase.CreateWebRtcRoomUseCase;
+
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class CreateWebRtcRoomWsController {
+
+	private final CreateWebRtcRoomUseCase createWebRtcRoomUseCase;
+
+	@MessageMapping("/room/{roomId}/rtc/room")
+	@SendTo("/topic/room/{roomId}")
+	public WsResponse<CreateRtcRoomResponseDto> update(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId
+	) throws OpenViduJavaClientException, OpenViduHttpException {
+		String createdRtcRoomId = createWebRtcRoomUseCase.createRoom(memberDetail.memberId(), roomId);
+
+		return WsResponse.success("CREATE_RTC_ROOM", CreateRtcRoomResponseDto.of(createdRtcRoomId));
+	}
+}

--- a/src/main/java/com/picpic/server/room/controller/ws/CreateWebRtcTokenWsController.java
+++ b/src/main/java/com/picpic/server/room/controller/ws/CreateWebRtcTokenWsController.java
@@ -1,0 +1,36 @@
+package com.picpic.server.room.controller.ws;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.CreateRtcTokenResponseDto;
+import com.picpic.server.room.service.usecase.CreateWebRtcTokenUseCase;
+
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class CreateWebRtcTokenWsController {
+
+	private final CreateWebRtcTokenUseCase createWebRtcTokenUseCase;
+
+	@MessageMapping("/room/{roomId}/rtc/token")
+	@SendToUser("/queue/room")
+	public WsResponse<CreateRtcTokenResponseDto> create(
+		@AuthenticationPrincipal MemberPrincipalDetail memberDetail,
+		@DestinationVariable String roomId
+	) throws OpenViduJavaClientException, OpenViduHttpException {
+		String createdRtcTokenURI = createWebRtcTokenUseCase.createToken(roomId, memberDetail);
+
+		return WsResponse.success("CREATE_RTC_TOKEN", CreateRtcTokenResponseDto.of(createdRtcTokenURI));
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/CreateRtcRoomResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/CreateRtcRoomResponseDto.java
@@ -1,0 +1,9 @@
+package com.picpic.server.room.dto;
+
+public record CreateRtcRoomResponseDto (
+	String rtcRoomId
+) {
+	public static CreateRtcRoomResponseDto of(String rtcRoomId) {
+		return new CreateRtcRoomResponseDto(rtcRoomId);
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/CreateRtcTokenResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/CreateRtcTokenResponseDto.java
@@ -1,0 +1,28 @@
+package com.picpic.server.room.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CreateRtcTokenResponseDto(
+	String sessionId,
+	String token
+) {
+	public static CreateRtcTokenResponseDto of(String rtcToken) {
+		CreateRtcTokenResponseDtoBuilder builder = CreateRtcTokenResponseDto.builder();
+
+		String[] splitArr = rtcToken.split("\\?")[1].split("&");
+
+		for(String split: splitArr) {
+			String[] keyValue = split.split("=");
+			if(keyValue.length == 2) {
+				if ("sessionId".equals(keyValue[0])) {
+					builder.sessionId(keyValue[1]);
+				} else if ("token".equals(keyValue[0])) {
+					builder.token(keyValue[1]);
+				}
+			}
+		}
+
+		return builder.build();
+	}
+}

--- a/src/main/java/com/picpic/server/room/dto/UpdateMemberRtcStateResponseDto.java
+++ b/src/main/java/com/picpic/server/room/dto/UpdateMemberRtcStateResponseDto.java
@@ -1,0 +1,20 @@
+package com.picpic.server.room.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateMemberRtcStateResponseDto (
+	String nickname,
+	MemberRtcState state
+) {
+	public enum MemberRtcState {
+		CONNECTED, DISCONNECTED
+	}
+
+	public static UpdateMemberRtcStateResponseDto of(String nickname, MemberRtcState state) {
+		return UpdateMemberRtcStateResponseDto.builder()
+			.nickname(nickname)
+			.state(state)
+			.build();
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/CreateWebRtcRoomService.java
+++ b/src/main/java/com/picpic/server/room/service/CreateWebRtcRoomService.java
@@ -1,0 +1,46 @@
+package com.picpic.server.room.service;
+
+import org.springframework.stereotype.Service;
+
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.service.usecase.CreateWebRtcRoomUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+
+import io.openvidu.java.client.OpenVidu;
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import io.openvidu.java.client.Session;
+import io.openvidu.java.client.SessionProperties;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateWebRtcRoomService implements CreateWebRtcRoomUseCase {
+
+	private final OpenVidu openvidu;
+
+	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+
+	@Override
+	public String createRoom(Long creatorId, String roomId)	throws OpenViduJavaClientException, OpenViduHttpException {
+
+		validateCreatorId(roomId, creatorId);
+
+		SessionProperties.Builder builder = new SessionProperties.Builder();
+		SessionProperties properties = builder.customSessionId(roomId).build();
+
+		Session session = openvidu.createSession(properties);
+
+		return session.getSessionId();
+	}
+
+	private void validateCreatorId (String roomId, Long requestMemberId) {
+		RoomMember actualCreator = redisRoomQueryUseCase.getCreator(roomId);
+
+		if(!actualCreator.getMemberId().equals(requestMemberId)) {
+			throw new WsException(WsErrorCode.ACCESS_DENIED_CREATOR_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/CreateWebRtcTokenService.java
+++ b/src/main/java/com/picpic/server/room/service/CreateWebRtcTokenService.java
@@ -1,0 +1,68 @@
+package com.picpic.server.room.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+import com.picpic.server.common.exception.WsErrorCode;
+import com.picpic.server.common.exception.WsException;
+import com.picpic.server.room.domain.RoomMember;
+import com.picpic.server.room.service.usecase.CreateWebRtcTokenUseCase;
+import com.picpic.server.room.service.usecase.RedisRoomQueryUseCase;
+
+import io.openvidu.java.client.Connection;
+import io.openvidu.java.client.ConnectionProperties;
+import io.openvidu.java.client.OpenVidu;
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import io.openvidu.java.client.Session;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateWebRtcTokenService implements CreateWebRtcTokenUseCase {
+
+	private final OpenVidu openvidu;
+
+	private final RedisRoomQueryUseCase redisRoomQueryUseCase;
+
+	private final ObjectMapper om;
+
+	@Override
+	public String createToken(String roomId, MemberPrincipalDetail memberDetail) throws OpenViduJavaClientException, OpenViduHttpException {
+		Session session = openvidu.getActiveSession(roomId);
+
+		if (session == null) {
+			throw new WsException(WsErrorCode.NOT_FOUND_ROOM);
+		}
+
+		validateRoomMember(roomId, memberDetail.memberId());
+
+		ConnectionProperties.Builder connectionBuilder = new ConnectionProperties.Builder();
+
+		try {
+			connectionBuilder.data(om.writeValueAsString(memberDetail));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+
+		ConnectionProperties properties = connectionBuilder.build();
+		Connection connection = session.createConnection(properties);
+		return connection.getToken();
+	}
+
+	private void validateRoomMember(String roomId, Long memberId) {
+		List<RoomMember> roomMembers = redisRoomQueryUseCase.searchMember(roomId);
+
+		long count = roomMembers.stream().filter(member ->
+			member.getMemberId().equals(memberId)
+		).count();
+
+		if(count == 0) {
+			throw new WsException(WsErrorCode.USER_NOT_IN_ROOM);
+		}
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/UpdateOVMemberStateService.java
+++ b/src/main/java/com/picpic/server/room/service/UpdateOVMemberStateService.java
@@ -1,0 +1,68 @@
+package com.picpic.server.room.service;
+
+import java.util.Map;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picpic.server.common.response.WsResponse;
+import com.picpic.server.room.dto.UpdateMemberRtcStateResponseDto;
+import com.picpic.server.room.service.usecase.UpdateOVMemberStateUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateOVMemberStateService implements UpdateOVMemberStateUseCase {
+
+	private final ObjectMapper objectMapper;
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Override
+	public void updateMemberState(String payload) throws JsonProcessingException {
+
+		Map<String, Object> payloadMap = parseToMap(payload);
+
+		String event = payloadMap.get("event").toString();
+		String roomId = payloadMap.get("sessionId").toString();
+
+		UpdateMemberRtcStateResponseDto response;
+
+		switch (event) {
+			case "participantJoined":
+				response = UpdateMemberRtcStateResponseDto.of(
+					getMemberNickname(payloadMap),
+					UpdateMemberRtcStateResponseDto.MemberRtcState.CONNECTED
+				);
+
+				messagingTemplate.convertAndSend("/topic/room/" + roomId, WsResponse.success("RTC_MEMBER_IN", response));
+				break;
+
+			case "participantLeft":
+				response = UpdateMemberRtcStateResponseDto.of(
+					getMemberNickname(payloadMap),
+					UpdateMemberRtcStateResponseDto.MemberRtcState.DISCONNECTED
+				);
+
+				messagingTemplate.convertAndSend("/topic/room/" + roomId, WsResponse.success("RTC_MEMBER_OUT", response));
+				break;
+		}
+	}
+
+	private Map<String, Object> parseToMap(String payload) throws JsonProcessingException {
+		Map<String, Object> map = objectMapper.readValue(payload, Map.class);
+
+		return map;
+	}
+
+	private String getMemberNickname(Map<String, Object> payloadMap) throws JsonProcessingException {
+		String serverData = (String) payloadMap.get("serverData");
+
+		Map<String, Object> serverDataMap = objectMapper.readValue(serverData, Map.class);
+
+		return serverDataMap.get("nickName").toString();
+	}
+}

--- a/src/main/java/com/picpic/server/room/service/usecase/CreateWebRtcRoomUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/CreateWebRtcRoomUseCase.java
@@ -1,0 +1,8 @@
+package com.picpic.server.room.service.usecase;
+
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+
+public interface CreateWebRtcRoomUseCase {
+	String createRoom(Long creatorId, String roomId) throws OpenViduJavaClientException, OpenViduHttpException;
+}

--- a/src/main/java/com/picpic/server/room/service/usecase/CreateWebRtcTokenUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/CreateWebRtcTokenUseCase.java
@@ -1,0 +1,10 @@
+package com.picpic.server.room.service.usecase;
+
+import com.picpic.server.common.auth.MemberPrincipalDetail;
+
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+
+public interface CreateWebRtcTokenUseCase {
+	String createToken(String roomId, MemberPrincipalDetail memberDetail) throws OpenViduJavaClientException, OpenViduHttpException;
+}

--- a/src/main/java/com/picpic/server/room/service/usecase/UpdateOVMemberStateUseCase.java
+++ b/src/main/java/com/picpic/server/room/service/usecase/UpdateOVMemberStateUseCase.java
@@ -1,0 +1,8 @@
+package com.picpic.server.room.service.usecase;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface UpdateOVMemberStateUseCase {
+
+	void updateMemberState(String payload) throws JsonProcessingException;
+}


### PR DESCRIPTION
<!--
[PR 제목 작성 규칙]
형식: <태그>/#<이슈번호>: 작업 내용 요약  
예시: feat/#6: 로그인 페이지 생성  
사용 가능한 태그: feat, fix, refactor, docs, chore, test, style, infra
-->

## ✨ 작업 내용
<!-- 어떤 작업을 했는지 요약해주세요 -->
- OpenVidu WebRTC 기능 추가
  1. webRTC 방 개설 (WS)
    - endpoint: `/room/{roomId}/rtc/room`
    - 해당 방 전체에 브로드캐스트: `/topic/room/{roomId}`에 브로드캐스트
    - 화상 연결을 위한 webRTC 방(세션) 개설 

  2. webRTC 연결 Token (WS)
    - endpoint: `/room/{roomId}/rtc/token`
    - token을 요청한 멤버에게만 알림: `/user/queue/room`에 브로드캐스트
    - 개설된 webRTC 방(세션)에 연결하기 위한 token 및 방의 sessionId 요청 

  3. webRTC WebHook 추가
    - endpoint: `/api/webhooks/openvidu`
    - openvidu 서버로부터 멤버 입장 및 퇴장 이벤트를 수신하여, 해당 방에 이벤트를 브로드캐스트
    - 참고: https://docs.openvidu.io/en/stable/reference-docs/openvidu-server-webhook

  4. openvidu 서버를 docker-compose에 추가
    - 주요 환경 변수는 별도의 파일로 관리(노션에 첨부)


